### PR TITLE
Style section titles, hide contact text on desktop, and add service pages

### DIFF
--- a/gutters.html
+++ b/gutters.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <!-- Metadata -->
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Gutters - Romano Roofing Co</title>
+    <!-- Favicon -->
+    <link rel="icon" href="favicon.ico" type="image/x-icon">
+    <!-- Fonts and Icons -->
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
+    <link href="https://fonts.googleapis.com/css?family=Merriweather:400,700&display=swap" rel="stylesheet">
+    <!-- Stylesheet -->
+    <link rel="stylesheet" href="styles.css">
+    <!-- Scripts -->
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+</head>
+<body>
+    <header class="header">
+        <div class="top-bar">
+            <a href="tel:+17735318298"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8298</span></a>
+            <a href="mailto:romanoroofingco@gmail.com"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
+        </div>
+        <nav class="main-nav">
+            <div class="logo-container">
+                <a href="index.html">
+                    <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
+                </a>
+            </div>
+            <ul>
+                <li><a href="index.html#solutions">Solutions</a></li>
+                <li><a href="index.html#about">About Us</a></li>
+                <li><a href="index.html#projects">Projects</a></li>
+                <li><a href="index.html#testimonials">Testimonials</a></li>
+                <li><a href="index.html#contact">Contact</a></li>
+            </ul>
+            <div class="hamburger"><i class="fas fa-bars"></i></div>
+            <div class="mobile-menu">
+                <ul>
+                    <li><a href="index.html#solutions">Solutions</a></li>
+                    <li><a href="index.html#about">About Us</a></li>
+                    <li><a href="index.html#projects">Projects</a></li>
+                    <li><a href="index.html#testimonials">Testimonials</a></li>
+                    <li><a href="index.html#contact">Contact</a></li>
+                </ul>
+            </div>
+        </nav>
+    </header>
+
+    <div id="mobile-bar" class="mobile-contact-bar">
+        <a href="tel:+11234567890"><i class="fas fa-phone"></i> Call Us</a>
+        <a href="index.html#contact" class="btn">Get a Free Quote</a>
+    </div>
+
+    <section class="service-detail">
+        <h2>Gutters</h2>
+        <p>Ensure proper water diversion with expert gutter installation and maintenance solutions.</p>
+    </section>
+
+    <footer class="footer">
+        <p>Licensed, Insured & Bonded!</p>
+        <p>&copy; 2024 Romano Roofing Co. </p>
+        <br>
+        <br>
+        <br>
+        <div class="sub-footer">
+            © Copyright 2024 | Developed by <a href="https://SaasProductized.com" target="_blank" style="color: inherit;">SaaS Productized Co</a>. | All Rights Reserved
+        </div>
+    </footer>
+
+    <script src="scripts.js"></script>
+</body>
+</html>
+

--- a/index.html
+++ b/index.html
@@ -81,21 +81,25 @@
                 <i class="fas fa-toolbox"></i>
                 <h3>Roof Repair</h3>
                 <p>Quick and efficient roof repair services to address leaks, damages, and more.</p>
+                <a href="roof-repair.html" class="btn read-more-btn">Read More</a>
             </div>
             <div class="solution-item">
                 <i class="fas fa-home"></i>
                 <h3>Roof Installation</h3>
                 <p>Professional installation services using the highest quality materials.</p>
+                <a href="roof-installation.html" class="btn read-more-btn">Read More</a>
             </div>
             <div class="solution-item">
                 <i class="fas fa-water"></i>
                 <h3>Gutters</h3>
                 <p>Ensure proper water diversion with our gutter installation and repair services.</p>
+                <a href="gutters.html" class="btn read-more-btn">Read More</a>
             </div>
             <div class="solution-item">
                 <i class="fas fa-paint-roller"></i>
                 <h3>Siding</h3>
                 <p>Protect and beautify your home with our durable siding solutions.</p>
+                <a href="siding.html" class="btn read-more-btn">Read More</a>
             </div>
         </div>
     </section>

--- a/roof-installation.html
+++ b/roof-installation.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <!-- Metadata -->
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Roof Installation - Romano Roofing Co</title>
+    <!-- Favicon -->
+    <link rel="icon" href="favicon.ico" type="image/x-icon">
+    <!-- Fonts and Icons -->
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
+    <link href="https://fonts.googleapis.com/css?family=Merriweather:400,700&display=swap" rel="stylesheet">
+    <!-- Stylesheet -->
+    <link rel="stylesheet" href="styles.css">
+    <!-- Scripts -->
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+</head>
+<body>
+    <header class="header">
+        <div class="top-bar">
+            <a href="tel:+17735318298"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8298</span></a>
+            <a href="mailto:romanoroofingco@gmail.com"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
+        </div>
+        <nav class="main-nav">
+            <div class="logo-container">
+                <a href="index.html">
+                    <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
+                </a>
+            </div>
+            <ul>
+                <li><a href="index.html#solutions">Solutions</a></li>
+                <li><a href="index.html#about">About Us</a></li>
+                <li><a href="index.html#projects">Projects</a></li>
+                <li><a href="index.html#testimonials">Testimonials</a></li>
+                <li><a href="index.html#contact">Contact</a></li>
+            </ul>
+            <div class="hamburger"><i class="fas fa-bars"></i></div>
+            <div class="mobile-menu">
+                <ul>
+                    <li><a href="index.html#solutions">Solutions</a></li>
+                    <li><a href="index.html#about">About Us</a></li>
+                    <li><a href="index.html#projects">Projects</a></li>
+                    <li><a href="index.html#testimonials">Testimonials</a></li>
+                    <li><a href="index.html#contact">Contact</a></li>
+                </ul>
+            </div>
+        </nav>
+    </header>
+
+    <div id="mobile-bar" class="mobile-contact-bar">
+        <a href="tel:+11234567890"><i class="fas fa-phone"></i> Call Us</a>
+        <a href="index.html#contact" class="btn">Get a Free Quote</a>
+    </div>
+
+    <section class="service-detail">
+        <h2>Roof Installation</h2>
+        <p>Professional installation services using the highest quality materials for a durable, beautiful roof.</p>
+    </section>
+
+    <footer class="footer">
+        <p>Licensed, Insured & Bonded!</p>
+        <p>&copy; 2024 Romano Roofing Co. </p>
+        <br>
+        <br>
+        <br>
+        <div class="sub-footer">
+            © Copyright 2024 | Developed by <a href="https://SaasProductized.com" target="_blank" style="color: inherit;">SaaS Productized Co</a>. | All Rights Reserved
+        </div>
+    </footer>
+
+    <script src="scripts.js"></script>
+</body>
+</html>
+

--- a/roof-repair.html
+++ b/roof-repair.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <!-- Metadata -->
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Roof Repair - Romano Roofing Co</title>
+    <!-- Favicon -->
+    <link rel="icon" href="favicon.ico" type="image/x-icon">
+    <!-- Fonts and Icons -->
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
+    <link href="https://fonts.googleapis.com/css?family=Merriweather:400,700&display=swap" rel="stylesheet">
+    <!-- Stylesheet -->
+    <link rel="stylesheet" href="styles.css">
+    <!-- Scripts -->
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+</head>
+<body>
+    <header class="header">
+        <div class="top-bar">
+            <a href="tel:+17735318298"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8298</span></a>
+            <a href="mailto:romanoroofingco@gmail.com"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
+        </div>
+        <nav class="main-nav">
+            <div class="logo-container">
+                <a href="index.html">
+                    <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
+                </a>
+            </div>
+            <ul>
+                <li><a href="index.html#solutions">Solutions</a></li>
+                <li><a href="index.html#about">About Us</a></li>
+                <li><a href="index.html#projects">Projects</a></li>
+                <li><a href="index.html#testimonials">Testimonials</a></li>
+                <li><a href="index.html#contact">Contact</a></li>
+            </ul>
+            <div class="hamburger"><i class="fas fa-bars"></i></div>
+            <div class="mobile-menu">
+                <ul>
+                    <li><a href="index.html#solutions">Solutions</a></li>
+                    <li><a href="index.html#about">About Us</a></li>
+                    <li><a href="index.html#projects">Projects</a></li>
+                    <li><a href="index.html#testimonials">Testimonials</a></li>
+                    <li><a href="index.html#contact">Contact</a></li>
+                </ul>
+            </div>
+        </nav>
+    </header>
+
+    <div id="mobile-bar" class="mobile-contact-bar">
+        <a href="tel:+11234567890"><i class="fas fa-phone"></i> Call Us</a>
+        <a href="index.html#contact" class="btn">Get a Free Quote</a>
+    </div>
+
+    <section class="service-detail">
+        <h2>Roof Repair</h2>
+        <p>From minor leaks to major damage, our roof repair services restore protection and extend the life of your roof.</p>
+    </section>
+
+    <footer class="footer">
+        <p>Licensed, Insured & Bonded!</p>
+        <p>&copy; 2024 Romano Roofing Co. </p>
+        <br>
+        <br>
+        <br>
+        <div class="sub-footer">
+            © Copyright 2024 | Developed by <a href="https://SaasProductized.com" target="_blank" style="color: inherit;">SaaS Productized Co</a>. | All Rights Reserved
+        </div>
+    </footer>
+
+    <script src="scripts.js"></script>
+</body>
+</html>
+

--- a/siding.html
+++ b/siding.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <!-- Metadata -->
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Siding - Romano Roofing Co</title>
+    <!-- Favicon -->
+    <link rel="icon" href="favicon.ico" type="image/x-icon">
+    <!-- Fonts and Icons -->
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
+    <link href="https://fonts.googleapis.com/css?family=Merriweather:400,700&display=swap" rel="stylesheet">
+    <!-- Stylesheet -->
+    <link rel="stylesheet" href="styles.css">
+    <!-- Scripts -->
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+</head>
+<body>
+    <header class="header">
+        <div class="top-bar">
+            <a href="tel:+17735318298"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8298</span></a>
+            <a href="mailto:romanoroofingco@gmail.com"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
+        </div>
+        <nav class="main-nav">
+            <div class="logo-container">
+                <a href="index.html">
+                    <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
+                </a>
+            </div>
+            <ul>
+                <li><a href="index.html#solutions">Solutions</a></li>
+                <li><a href="index.html#about">About Us</a></li>
+                <li><a href="index.html#projects">Projects</a></li>
+                <li><a href="index.html#testimonials">Testimonials</a></li>
+                <li><a href="index.html#contact">Contact</a></li>
+            </ul>
+            <div class="hamburger"><i class="fas fa-bars"></i></div>
+            <div class="mobile-menu">
+                <ul>
+                    <li><a href="index.html#solutions">Solutions</a></li>
+                    <li><a href="index.html#about">About Us</a></li>
+                    <li><a href="index.html#projects">Projects</a></li>
+                    <li><a href="index.html#testimonials">Testimonials</a></li>
+                    <li><a href="index.html#contact">Contact</a></li>
+                </ul>
+            </div>
+        </nav>
+    </header>
+
+    <div id="mobile-bar" class="mobile-contact-bar">
+        <a href="tel:+11234567890"><i class="fas fa-phone"></i> Call Us</a>
+        <a href="index.html#contact" class="btn">Get a Free Quote</a>
+    </div>
+
+    <section class="service-detail">
+        <h2>Siding</h2>
+        <p>Protect and beautify your home with our durable siding solutions that stand up to the elements.</p>
+    </section>
+
+    <footer class="footer">
+        <p>Licensed, Insured & Bonded!</p>
+        <p>&copy; 2024 Romano Roofing Co. </p>
+        <br>
+        <br>
+        <br>
+        <div class="sub-footer">
+            © Copyright 2024 | Developed by <a href="https://SaasProductized.com" target="_blank" style="color: inherit;">SaaS Productized Co</a>. | All Rights Reserved
+        </div>
+    </footer>
+
+    <script src="scripts.js"></script>
+</body>
+</html>
+

--- a/styles.css
+++ b/styles.css
@@ -7,6 +7,15 @@ body, h1, h2, h3, p, ul, li, a, img {
     font: inherit;
     vertical-align: baseline;
 }
+h1, h2, h3 {
+    font-weight: bold;
+}
+section h2 {
+    font-size: 2em;
+}
+section h3 {
+    font-size: 1.5em;
+}
 body {
     line-height: 1;
     font-family: 'Open Sans', sans-serif;
@@ -48,6 +57,9 @@ ul {
     color: #fff;
     padding: 0 10px;
     font-size: 0.9em;
+}
+.top-bar .contact-text {
+    display: none;
 }
 
 .logo-container {
@@ -103,6 +115,19 @@ ul {
     cursor: pointer;
 }
 .btn.primary-btn:hover {
+    background: #0056b3;
+}
+.btn.read-more-btn {
+    background: #007BFF;
+    color: #fff;
+    padding: 8px 15px;
+    border-radius: 5px;
+    cursor: pointer;
+    display: inline-block;
+    margin-top: 10px;
+    font-size: 0.9em;
+}
+.btn.read-more-btn:hover {
     background: #0056b3;
 }
 
@@ -324,8 +349,16 @@ ul {
         max-width: 100%;
     }
 }
-
-
+/* Service Detail */
+.service-detail {
+    text-align: center;
+    padding: 120px 20px 40px;
+}
+.service-detail p {
+    max-width: 800px;
+    margin: 0 auto;
+    line-height: 1.6;
+}
 /* Carousel styling */
 .carousel-container {
     display: flex;


### PR DESCRIPTION
## Summary
- Increase and embolden section headings and hide top-bar contact text to show only icons on desktop.
- Add "Read More" buttons for each service linking to new detailed pages.
- Introduce dedicated pages for roof repair, roof installation, gutters, and siding using existing site styling.

## Testing
- `npm test` (fails: could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68959cd4d5ec8321990f2cc33432d120