### PR TITLE
Replace phone number and add service area page

### DIFF
--- a/gutters.html
+++ b/gutters.html
@@ -19,7 +19,7 @@
 <body>
     <header class="header">
         <div class="top-bar">
-            <a href="tel:+17735318298"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8298</span></a>
+            <a href="tel:+17735318473"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8473</span></a>
             <a href="mailto:romanoroofingco@gmail.com"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
         </div>
         <nav class="main-nav">
@@ -49,13 +49,15 @@
     </header>
 
     <div id="mobile-bar" class="mobile-contact-bar">
-        <a href="tel:+11234567890"><i class="fas fa-phone"></i> Call Us</a>
-        <a href="index.html#contact" class="btn">Get a Free Quote</a>
+        <a href="service-area.html" class="service-area-link">Service Area</a>
+        <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
     </div>
 
     <section class="service-detail">
         <h2>Gutters</h2>
-        <p>Ensure proper water diversion with expert gutter installation and maintenance solutions.</p>
+        <p>Properly functioning gutters steer water away from your roof and foundation, preventing erosion and basement flooding.</p>
+        <p>We install seamless aluminum and sturdy steel systems sized for Chicagoland weather, and we can upgrade your home with leaf guards that reduce seasonal cleanings.</p>
+        <p>Routine inspections and cleaning keep gutters clear of debris, prolonging their life and protecting your home from costly water damage.</p>
     </section>
 
     <footer class="footer">

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
     <!-- Header -->
     <header class="header">
         <div class="top-bar">
-            <a href="tel:+17735318298"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8298</span></a>
+            <a href="tel:+17735318473"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8473</span></a>
             <a href="mailto:romanoroofingco@gmail.com"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
         </div>
         <nav class="main-nav">
@@ -57,8 +57,8 @@
 
     <!-- Mobile Contact Bar -->
     <div id="mobile-bar" class="mobile-contact-bar">
-        <a href="tel:+11234567890"><i class="fas fa-phone"></i> Call Us</a>
-        <a href="#contact" class="btn">Get a Free Quote</a>
+        <a href="service-area.html" class="service-area-link">Service Area</a>
+        <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
     </div>
 
     <!-- Main Banner -->
@@ -122,10 +122,6 @@
     <p>Your roof plays an essential role in preserving the comfort, safety, and beauty of your home. Wood rot, missing or broken shingles, roof leaks, and other roof problems can affect your entire property. If ignored, these issues can lead to moisture intrusion, mold growth, pest problems, interior energy efficiency issues, and more. That's why the experts at Romano Roofing respond quickly to offer seamless roof repairs and roof replacements. We reinforce your roofing system at every layer. What's more, we install durable gutter systems to protect your roof and home from water damage.</p>
     <p>As your local Klaus Roofing Systems dealer, we have exclusive access to top-notch roofing materials, up-to-date training, and much more. With the Klaus Roofing Way, we guarantee exceptional craftsmanship, honest communication, and property protection throughout your roofing project. When you partner with us for your roof repair or replacement, you can be sure you're getting the best results!</p>
     <p>Our roofs are as durable as they are beautiful! Contact us today to schedule a free estimate on our roof repair, roof replacement, or gutter installation services. We proudly serve Illinois homeowners in Aurora, Joliet, Naperville, and nearby.</p>
-    <!-- Button Centered -->
-    <div class="center-btn-wrapper">
-        <a href="#contact" class="btn secondary-btn">Get a Free Quote</a>
-    </div>
 </section>
 
 

--- a/roof-installation.html
+++ b/roof-installation.html
@@ -19,7 +19,7 @@
 <body>
     <header class="header">
         <div class="top-bar">
-            <a href="tel:+17735318298"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8298</span></a>
+            <a href="tel:+17735318473"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8473</span></a>
             <a href="mailto:romanoroofingco@gmail.com"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
         </div>
         <nav class="main-nav">
@@ -49,13 +49,15 @@
     </header>
 
     <div id="mobile-bar" class="mobile-contact-bar">
-        <a href="tel:+11234567890"><i class="fas fa-phone"></i> Call Us</a>
-        <a href="index.html#contact" class="btn">Get a Free Quote</a>
+        <a href="service-area.html" class="service-area-link">Service Area</a>
+        <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
     </div>
 
     <section class="service-detail">
         <h2>Roof Installation</h2>
-        <p>Professional installation services using the highest quality materials for a durable, beautiful roof.</p>
+        <p>Our team replaces worn roofing with high-performance shingles and underlayments that stand up to harsh Midwest winters.</p>
+        <p>We begin with a detailed assessment and ventilation plan, then install ice and water barriers, synthetic underlayment, and durable flashing before laying the final roofing material.</p>
+        <p>Whether you choose architectural asphalt, metal, or flat roofing membranes, every project is backed by manufacturer warranties and our craftsmanship guarantee.</p>
     </section>
 
     <footer class="footer">

--- a/service-area.html
+++ b/service-area.html
@@ -4,7 +4,7 @@
     <!-- Metadata -->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Roof Repair - Romano Roofing Co</title>
+    <title>Service Area - Romano Roofing Co</title>
     <!-- Favicon -->
     <link rel="icon" href="favicon.ico" type="image/x-icon">
     <!-- Fonts and Icons -->
@@ -54,10 +54,51 @@
     </div>
 
     <section class="service-detail">
-        <h2>Roof Repair</h2>
-        <p>Leaks, missing shingles, and storm damage can compromise your entire home. Our technicians locate the source of issues and provide targeted repairs that restore your roof's integrity.</p>
-        <p>We replace damaged shingles, seal flashing around chimneys and vents, and address ventilation or decking problems to stop moisture before it spreads.</p>
-        <p>Timely repairs extend the life of your existing roof and help you avoid premature replacement costs.</p>
+        <h2>Our Service Area</h2>
+        <p>Romano Roofing Co proudly serves homeowners and businesses across the greater Chicagoland region. We bring quality roof repair, installation, and exterior solutions to communities throughout the area.</p>
+
+        <div class="map-container" style="margin:40px 0;">
+            <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d190365.24249809825!2d-87.940266!3d41.8333925!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x880e2ca06b43b56b%3A0xdd4c647347c54b0!2sChicago%2C%20IL!5e0!3m2!1sen!2sus!4v1691429123456!5m2!1sen!2sus" width="100%" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+        </div>
+
+        <table>
+            <thead>
+                <tr>
+                    <th>County</th>
+                    <th>Cities We Serve</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Cook, IL</td>
+                    <td>Bellwood, Berkeley, Bridgeview, Chicago Heights, Chicago Ridge, Country Club Hills, Flossmoor, Glenwood, Hazel Crest, Hickory Hills, Hillside, Homewood, Justice, La Grange, La Grange Park, Lemont, Markham, Matteson, Midlothian, Oak Forest, Olympia Fields, Orland Park, Palos Heights, Palos Hills, Palos Park, Park Forest, Richton Park, Steger, Tinley Park, Westchester, Western Springs, Willow Springs, Worth</td>
+                </tr>
+                <tr>
+                    <td>DuPage, IL</td>
+                    <td>Addison, Aurora, Carol Stream, Clarendon Hills, Darien, Downers Grove, Elmhurst, Eola, Glen Ellyn, Glendale Heights, Hinsdale, Lisle, Lombard, Naperville, Oak Brook, Villa Park, Warrenville, West Chicago, Westmont, Wheaton, Willowbrook, Winfield, Woodridge</td>
+                </tr>
+                <tr>
+                    <td>Grundy, IL</td>
+                    <td>Minooka, Morris</td>
+                </tr>
+                <tr>
+                    <td>Kane, IL</td>
+                    <td>Aurora, Batavia, Big Rock, Elburn, Geneva, Kaneville, Mooseheart, North Aurora, Saint Charles, Sugar Grove</td>
+                </tr>
+                <tr>
+                    <td>Kendall, IL</td>
+                    <td>Bristol, Montgomery, Oswego, Plano, Yorkville</td>
+                </tr>
+                <tr>
+                    <td>Will, IL</td>
+                    <td>Aurora, Bolingbrook, Channahon, Crest Hill, Crete, Elwood, Frankfort, Homer Glen, Joliet, Lockport, Manhattan, Mokena, Monee, Naperville, New Lenox, Plainfield, Romeoville, Shorewood, University Park</td>
+                </tr>
+            </tbody>
+        </table>
+
+        <div class="center-btn-wrapper" style="margin-top:40px;">
+            <a href="index.html#contact" class="btn primary-btn">Contact Us Today</a>
+        </div>
     </section>
 
     <footer class="footer">
@@ -74,4 +115,3 @@
     <script src="scripts.js"></script>
 </body>
 </html>
-

--- a/siding.html
+++ b/siding.html
@@ -19,7 +19,7 @@
 <body>
     <header class="header">
         <div class="top-bar">
-            <a href="tel:+17735318298"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8298</span></a>
+            <a href="tel:+17735318473"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8473</span></a>
             <a href="mailto:romanoroofingco@gmail.com"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
         </div>
         <nav class="main-nav">
@@ -49,13 +49,15 @@
     </header>
 
     <div id="mobile-bar" class="mobile-contact-bar">
-        <a href="tel:+11234567890"><i class="fas fa-phone"></i> Call Us</a>
-        <a href="index.html#contact" class="btn">Get a Free Quote</a>
+        <a href="service-area.html" class="service-area-link">Service Area</a>
+        <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
     </div>
 
     <section class="service-detail">
         <h2>Siding</h2>
-        <p>Protect and beautify your home with our durable siding solutions that stand up to the elements.</p>
+        <p>New siding refreshes curb appeal while shielding your structure from wind and moisture.</p>
+        <p>We offer vinyl, fiber cement, and engineered wood options in a variety of colors and profiles to match any architectural style.</p>
+        <p>Our installations include proper weather barriers and insulation to improve energy efficiency and keep your home looking great for decades.</p>
     </section>
 
     <footer class="footer">

--- a/styles.css
+++ b/styles.css
@@ -469,7 +469,7 @@ ul {
     color: #fff;
     position: relative;
     z-index: 500;
-    margin-top: 100px; /* Ensure separation from the main content */
+    margin-top: 150px; /* Ensure separation from the main content */
     box-sizing: border-box; /* Ensures proper padding and margin calculations */
     width: 100%;
 }


### PR DESCRIPTION
## Summary
- Update contact number to 773-531-8473 across site and remove Free Quote buttons
- Introduce service area page with Chicagoland map and county coverage table
- Expand service descriptions and adjust footer spacing for all pages

## Testing
- `npx htmlhint *.html` *(failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6895a05864948321a4cf4b696d45e627