### PR TITLE
Enhance header spacing and add project carousels

### DIFF
--- a/gutters.html
+++ b/gutters.html
@@ -55,6 +55,23 @@
 
     <section class="service-detail">
         <h2>Gutters</h2>
+        <div class="carousel-container">
+            <button class="carousel-arrow left-arrow" onclick="moveCarousel(-1)">&#10094;</button>
+            <div class="carousel">
+                <div class="carousel-images">
+                    <img src="1.jpg" alt="Team at work" class="carousel-img">
+                    <img src="2.jpeg" alt="Clean office space" class="carousel-img">
+                    <img src="3.png" alt="Tools and equipment" class="carousel-img">
+                    <img src="1.jpg" alt="Workshop" class="carousel-img">
+                    <img src="2.jpeg" alt="Cleaning Service" class="carousel-img">
+                    <img src="3.png" alt="Cleaning Service" class="carousel-img">
+                    <img src="1.jpg" alt="Team at work" class="carousel-img">
+                    <img src="2.jpeg" alt="Clean office space" class="carousel-img">
+                    <img src="3.png" alt="Tools and equipment" class="carousel-img">
+                </div>
+            </div>
+            <button class="carousel-arrow right-arrow" onclick="moveCarousel(1)">&#10095;</button>
+        </div>
         <p>Properly functioning gutters steer water away from your roof and foundation, preventing erosion and basement flooding.</p>
         <p>We install seamless aluminum and sturdy steel systems sized for Chicagoland weather, and we can upgrade your home with leaf guards that reduce seasonal cleanings.</p>
         <p>Routine inspections and cleaning keep gutters clear of debris, prolonging their life and protecting your home from costly water damage.</p>

--- a/index.html
+++ b/index.html
@@ -63,13 +63,13 @@
 
     <!-- Main Banner -->
     <section class="main-banner">
-        <br>
         <p>"Delivering top-tier roofing solutions across Chicagoland for over two decades."</p>
         <a href="#contact" class="btn primary-btn">Contact Us</a>
     </section>
     
     <!-- About Section -->
 <section id="about" class="about">
+    <h2>About Us</h2>
     <p>We are a family-owned business with over 20 years of experience in providing high quality roofing services to our community. Our team is committed to delivering quality and reliability in every project. Over the years, we've built a reputation for professionalism and craftsmanship. Our customers trust us for all their roofing needs, from minor repairs to complete roof replacements. We use the highest quality materials and cutting-edge techniques to ensure every roof is durable, efficient, and built to last. We stand behind our work with a satisfaction guarantee and are proud to serve both residential and commercial properties across Chicagoland.</p>
 </section>
 

--- a/roof-installation.html
+++ b/roof-installation.html
@@ -55,6 +55,23 @@
 
     <section class="service-detail">
         <h2>Roof Installation</h2>
+        <div class="carousel-container">
+            <button class="carousel-arrow left-arrow" onclick="moveCarousel(-1)">&#10094;</button>
+            <div class="carousel">
+                <div class="carousel-images">
+                    <img src="1.jpg" alt="Team at work" class="carousel-img">
+                    <img src="2.jpeg" alt="Clean office space" class="carousel-img">
+                    <img src="3.png" alt="Tools and equipment" class="carousel-img">
+                    <img src="1.jpg" alt="Workshop" class="carousel-img">
+                    <img src="2.jpeg" alt="Cleaning Service" class="carousel-img">
+                    <img src="3.png" alt="Cleaning Service" class="carousel-img">
+                    <img src="1.jpg" alt="Team at work" class="carousel-img">
+                    <img src="2.jpeg" alt="Clean office space" class="carousel-img">
+                    <img src="3.png" alt="Tools and equipment" class="carousel-img">
+                </div>
+            </div>
+            <button class="carousel-arrow right-arrow" onclick="moveCarousel(1)">&#10095;</button>
+        </div>
         <p>Our team replaces worn roofing with high-performance shingles and underlayments that stand up to harsh Midwest winters.</p>
         <p>We begin with a detailed assessment and ventilation plan, then install ice and water barriers, synthetic underlayment, and durable flashing before laying the final roofing material.</p>
         <p>Whether you choose architectural asphalt, metal, or flat roofing membranes, every project is backed by manufacturer warranties and our craftsmanship guarantee.</p>

--- a/roof-repair.html
+++ b/roof-repair.html
@@ -55,6 +55,23 @@
 
     <section class="service-detail">
         <h2>Roof Repair</h2>
+        <div class="carousel-container">
+            <button class="carousel-arrow left-arrow" onclick="moveCarousel(-1)">&#10094;</button>
+            <div class="carousel">
+                <div class="carousel-images">
+                    <img src="1.jpg" alt="Team at work" class="carousel-img">
+                    <img src="2.jpeg" alt="Clean office space" class="carousel-img">
+                    <img src="3.png" alt="Tools and equipment" class="carousel-img">
+                    <img src="1.jpg" alt="Workshop" class="carousel-img">
+                    <img src="2.jpeg" alt="Cleaning Service" class="carousel-img">
+                    <img src="3.png" alt="Cleaning Service" class="carousel-img">
+                    <img src="1.jpg" alt="Team at work" class="carousel-img">
+                    <img src="2.jpeg" alt="Clean office space" class="carousel-img">
+                    <img src="3.png" alt="Tools and equipment" class="carousel-img">
+                </div>
+            </div>
+            <button class="carousel-arrow right-arrow" onclick="moveCarousel(1)">&#10095;</button>
+        </div>
         <p>Leaks, missing shingles, and storm damage can compromise your entire home. Our technicians locate the source of issues and provide targeted repairs that restore your roof's integrity.</p>
         <p>We replace damaged shingles, seal flashing around chimneys and vents, and address ventilation or decking problems to stop moisture before it spreads.</p>
         <p>Timely repairs extend the life of your existing roof and help you avoid premature replacement costs.</p>

--- a/siding.html
+++ b/siding.html
@@ -55,6 +55,23 @@
 
     <section class="service-detail">
         <h2>Siding</h2>
+        <div class="carousel-container">
+            <button class="carousel-arrow left-arrow" onclick="moveCarousel(-1)">&#10094;</button>
+            <div class="carousel">
+                <div class="carousel-images">
+                    <img src="1.jpg" alt="Team at work" class="carousel-img">
+                    <img src="2.jpeg" alt="Clean office space" class="carousel-img">
+                    <img src="3.png" alt="Tools and equipment" class="carousel-img">
+                    <img src="1.jpg" alt="Workshop" class="carousel-img">
+                    <img src="2.jpeg" alt="Cleaning Service" class="carousel-img">
+                    <img src="3.png" alt="Cleaning Service" class="carousel-img">
+                    <img src="1.jpg" alt="Team at work" class="carousel-img">
+                    <img src="2.jpeg" alt="Clean office space" class="carousel-img">
+                    <img src="3.png" alt="Tools and equipment" class="carousel-img">
+                </div>
+            </div>
+            <button class="carousel-arrow right-arrow" onclick="moveCarousel(1)">&#10095;</button>
+        </div>
         <p>New siding refreshes curb appeal while shielding your structure from wind and moisture.</p>
         <p>We offer vinyl, fiber cement, and engineered wood options in a variety of colors and profiles to match any architectural style.</p>
         <p>Our installations include proper weather barriers and insulation to improve energy efficiency and keep your home looking great for decades.</p>

--- a/styles.css
+++ b/styles.css
@@ -115,6 +115,7 @@ ul {
     background: url('2.jpeg') no-repeat center center/cover; /* Background for the main banner */
     text-align: center;
     padding: 60px 20px;
+    margin-top: 120px;
     color: #fff;
     font-family: 'Merriweather', serif;
     position: relative;
@@ -200,6 +201,13 @@ ul {
     width: 100%;
 }
 
+.about h2 {
+    position: relative;
+    z-index: 2;
+    color: #fff;
+    margin-bottom: 20px;
+}
+
 .about::before {
     content: "";
     position: absolute;
@@ -217,6 +225,8 @@ ul {
     font-size: 1.2em; /* Adjust the text size if needed */
     color: #fff; /* Keep the text white for better readability */
     line-height: 1.6; /* Improves readability */
+    max-width: 800px;
+    margin: 0 auto;
 }
 
 
@@ -394,7 +404,7 @@ ul {
 .carousel {
     overflow: hidden;
     width: 90%;
-    max-width: 800px; /* Limit the width on larger screens */
+    max-width: 1000px; /* Limit the width on larger screens */
     position: relative;
     display: flex;
     align-items: center;
@@ -408,6 +418,8 @@ ul {
 .carousel-img {
     width: 33%; /* Show 2-3 images per view */
     margin: 0;
+    height: 300px;
+    object-fit: cover;
 }
 
 /* Adjusting button visibility */


### PR DESCRIPTION
## Summary
- push main banner below fixed header and tighten About text with a new "About Us" heading
- enlarge project carousel and center About section copy
- embed project carousel below headings on all service pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689668f7f74083218ec8965bd53b32f5