### PR TITLE
Refine layout and slider interaction

### DIFF
--- a/gutters.html
+++ b/gutters.html
@@ -54,7 +54,7 @@
     </div>
 
     <section class="service-detail">
-        <h2>Gutters</h2>
+        <h2><i class="fas fa-water service-icon"></i> Gutters</h2>
         <div class="carousel-container">
             <button class="carousel-arrow left-arrow" onclick="moveCarousel(-1)">&#10094;</button>
             <div class="carousel">

--- a/roof-installation.html
+++ b/roof-installation.html
@@ -54,7 +54,7 @@
     </div>
 
     <section class="service-detail">
-        <h2>Roof Installation</h2>
+        <h2><i class="fas fa-home service-icon"></i> Roof Installation</h2>
         <div class="carousel-container">
             <button class="carousel-arrow left-arrow" onclick="moveCarousel(-1)">&#10094;</button>
             <div class="carousel">

--- a/roof-repair.html
+++ b/roof-repair.html
@@ -54,7 +54,7 @@
     </div>
 
     <section class="service-detail">
-        <h2>Roof Repair</h2>
+        <h2><i class="fas fa-toolbox service-icon"></i> Roof Repair</h2>
         <div class="carousel-container">
             <button class="carousel-arrow left-arrow" onclick="moveCarousel(-1)">&#10094;</button>
             <div class="carousel">

--- a/scripts.js
+++ b/scripts.js
@@ -78,25 +78,22 @@ document.addEventListener("DOMContentLoaded", function () {
     let currentIndex = 0;
     const totalImages = carouselImages.length;
     const imagesToShow = 3;  // Showing 3 images at a time
+    const maxIndex = totalImages - imagesToShow;
     let imageWidth = carouselImages[0].clientWidth + 20; // Image width + margin/padding
 
     // Right arrow click event
     if (rightArrow) {
         rightArrow.addEventListener('click', () => {
-            if (currentIndex < totalImages - imagesToShow) {
-                currentIndex++;
-                updateCarousel();
-            }
+            currentIndex = currentIndex >= maxIndex ? 0 : currentIndex + 1;
+            updateCarousel();
         });
     }
 
     // Left arrow click event
     if (leftArrow) {
         leftArrow.addEventListener('click', () => {
-            if (currentIndex > 0) {
-                currentIndex--;
-                updateCarousel();
-            }
+            currentIndex = currentIndex <= 0 ? maxIndex : currentIndex - 1;
+            updateCarousel();
         });
     }
 

--- a/service-area.html
+++ b/service-area.html
@@ -54,7 +54,7 @@
     </div>
 
     <section class="service-detail">
-        <h2>Our Service Area</h2>
+        <h2><i class="fas fa-map-marker-alt service-icon"></i> Our Service Area</h2>
         <p>Romano Roofing Co proudly serves homeowners and businesses across the greater Chicagoland region. We bring quality roof repair, installation, and exterior solutions to communities throughout the area.</p>
 
         <div class="map-container" style="margin:40px 0;">

--- a/siding.html
+++ b/siding.html
@@ -54,7 +54,7 @@
     </div>
 
     <section class="service-detail">
-        <h2>Siding</h2>
+        <h2><i class="fas fa-paint-roller service-icon"></i> Siding</h2>
         <div class="carousel-container">
             <button class="carousel-arrow left-arrow" onclick="moveCarousel(-1)">&#10094;</button>
             <div class="carousel">

--- a/styles.css
+++ b/styles.css
@@ -116,7 +116,7 @@ ul {
     background: url('2.jpeg') no-repeat center center/cover; /* Background for the main banner */
     text-align: center;
     padding: 60px 20px;
-    margin-top: 100px;
+    margin-top: 0;
     color: #fff;
     font-family: 'Merriweather', serif;
     position: relative;
@@ -128,6 +128,7 @@ ul {
     font-weight: 600;
     font-style: italic;
     color: #fff;
+    text-shadow: 0 0 10px rgba(255, 87, 51, 0.6);
 }
 
 .btn.primary-btn {
@@ -383,12 +384,24 @@ ul {
 /* Service Detail */
 .service-detail {
     text-align: center;
-    padding: 100px 20px 40px;
+    padding: 120px 20px 40px;
 }
 .service-detail p {
     max-width: 800px;
     margin: 20px auto 0;
     line-height: 1.6;
+}
+
+.service-detail h2 {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    padding-top: 20px;
+}
+
+.service-detail .service-icon {
+    color: #FF5733;
 }
 /* Carousel styling */
 .carousel-container {
@@ -640,11 +653,15 @@ body {
     }
 
     .main-banner {
-        margin-top: 80px;
+        margin-top: 0;
     }
 
     .service-detail {
-        padding-top: 80px;
+        padding-top: 100px;
+    }
+
+    .service-detail h2 {
+        padding-top: 10px;
     }
 
     .mobile-menu.show {


### PR DESCRIPTION
## Summary
- Remove banner/header gaps and add orange glow to hero quote
- Display matching service icons on each service page with improved spacing
- Loop image carousels infinitely when navigating

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68966fb9ca1083219c2584582e843f99