### PR TITLE
Fix logo link and adjust banner spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
         </div>
         <nav class="main-nav">
             <div class="logo-container">
-    <a href="https://romanoroofing.com">
+    <a href="https://romanoroofing.co">
         <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
     </a>
 </div>

--- a/styles.css
+++ b/styles.css
@@ -115,7 +115,7 @@ ul {
 .main-banner {
     background: url('2.jpeg') no-repeat center center/cover; /* Background for the main banner */
     text-align: center;
-    padding: 60px 20px;
+    padding: 140px 20px 60px; /* Extra top padding keeps quote clear of fixed header */
     margin-top: 0;
     color: #fff;
     font-family: 'Merriweather', serif;
@@ -654,6 +654,7 @@ body {
 
     .main-banner {
         margin-top: 0;
+        padding-top: 100px; /* Add breathing room above quote on mobile */
     }
 
     .service-detail {


### PR DESCRIPTION
## Summary
- Correct main logo link to point to `romanoroofing.co`
- Increase top padding on the main banner to prevent the quote from being obscured by the header and add extra mobile spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896728436008321b8489f0a62efce89