### PR TITLE
Add careers page and improve email usability

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <!-- Metadata -->
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Careers - Romano Roofing Co</title>
+    <!-- Favicon -->
+    <link rel="icon" href="favicon.ico" type="image/x-icon">
+    <!-- Fonts and Icons -->
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
+    <link href="https://fonts.googleapis.com/css?family=Merriweather:400,700&display=swap" rel="stylesheet">
+    <!-- Stylesheet -->
+    <link rel="stylesheet" href="styles.css">
+    <!-- Scripts -->
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+</head>
+<body>
+    <header class="header">
+        <div class="top-bar">
+            <a href="tel:+17735318473"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8473</span></a>
+            <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
+        </div>
+        <nav class="main-nav">
+            <div class="logo-container">
+                <a href="index.html">
+                    <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
+                </a>
+            </div>
+            <ul>
+                <li><a href="index.html#solutions">Solutions</a></li>
+                <li><a href="index.html#about">About Us</a></li>
+                <li><a href="index.html#projects">Projects</a></li>
+                <li><a href="index.html#testimonials">Testimonials</a></li>
+                <li><a href="index.html#contact">Contact</a></li>
+            </ul>
+            <div class="hamburger"><i class="fas fa-bars"></i></div>
+            <div class="mobile-menu">
+                <ul>
+                    <li><a href="index.html#solutions">Solutions</a></li>
+                    <li><a href="index.html#about">About Us</a></li>
+                    <li><a href="index.html#projects">Projects</a></li>
+                    <li><a href="index.html#testimonials">Testimonials</a></li>
+                    <li><a href="index.html#contact">Contact</a></li>
+                </ul>
+            </div>
+        </nav>
+    </header>
+
+    <div id="mobile-bar" class="mobile-contact-bar">
+        <a href="service-area.html" class="service-area-link">Service Area</a>
+        <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
+    </div>
+
+    <section class="service-detail careers-section">
+        <h2>Join Our Team!</h2>
+        <img src="1.jpg" alt="Careers at Romano Roofing Co" class="careers-image" />
+        <p>At Romano Roofing Co, we don’t just build roofs — we build careers. If you’re looking for a place where you can grow, be part of a positive and skilled team, and take pride in your daily work, you’ve come to the right place.</p>
+
+        <img src="2.jpeg" alt="Careers at Romano Roofing Co" class="careers-image" />
+
+        <h3>A Positive and Professional Environment</h3>
+        <p>We take pride in the atmosphere we’ve created. Our team works in harmony to deliver quality roofing solutions with care, precision, and professionalism. We encourage creativity, teamwork, and a strong work ethic while fostering camaraderie and respect.</p>
+
+        <img src="3.png" alt="Careers at Romano Roofing Co" class="careers-image" />
+
+        <h3>Year-Round Reliable Work</h3>
+        <p>We offer more than seasonal work. Thanks to our wide range of roofing and exterior services, we provide full-time, year-round employment opportunities so our staff can rely on a stable income all year long.</p>
+
+        <img src="1.jpg" alt="Careers at Romano Roofing Co" class="careers-image" />
+
+        <h3>Top Pay &amp; Great Benefits</h3>
+        <ul>
+            <li>Top-tier pay for skilled work</li>
+            <li>Uniforms, boots, and seasonal gear provided</li>
+            <li>Healthcare benefits for office staff and project managers</li>
+            <li>Paid vacation days for foremen and above</li>
+            <li>Support for continuing education and industry certifications</li>
+        </ul>
+
+        <img src="2.jpeg" alt="Careers at Romano Roofing Co" class="careers-image" />
+
+        <h3>We Support Our Community</h3>
+        <p>We’re proud to give back — from helping neighbors after storms to supporting local causes. At Romano Roofing Co, your work makes a lasting impact on both our clients and our community.</p>
+
+        <img src="3.png" alt="Careers at Romano Roofing Co" class="careers-image" />
+
+        <h3>We’re Hiring!</h3>
+        <p>If you’re passionate, hardworking, and ready to grow in a rewarding environment, apply for one of our open positions:</p>
+
+        <img src="1.jpg" alt="Careers at Romano Roofing Co" class="careers-image" />
+        <ul>
+            <li>Production Manager</li>
+            <li>Account Manager</li>
+            <li>Roofing Designer</li>
+            <li>Project Manager</li>
+            <li>Commercial Estimator</li>
+            <li>Maintenance Foreman</li>
+            <li>Construction Foreman</li>
+            <li>Roofing Technician</li>
+            <li>Construction Crew Member</li>
+            <li>Maintenance Crew Member</li>
+        </ul>
+
+        <img src="2.jpeg" alt="Careers at Romano Roofing Co" class="careers-image" />
+
+        <p>To apply, please email your resume to <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank">romanoroofingco@gmail.com</a> or visit our <a href="index.html#contact">Contact Section</a>.</p>
+    </section>
+
+    <footer class="footer">
+        <p>Licensed, Insured &amp; Bonded!</p>
+        <p>&copy; 2024 Romano Roofing Co. </p>
+        <br>
+        <br>
+        <br>
+        <div class="sub-footer">
+            © Copyright 2024 | Developed by <a href="https://SaasProductized.com" target="_blank" style="color: inherit;">SaaS Productized Co</a>. | All Rights Reserved
+        </div>
+    </footer>
+
+    <script src="scripts.js"></script>
+</body>
+</html>
+

--- a/gutters.html
+++ b/gutters.html
@@ -20,7 +20,7 @@
     <header class="header">
         <div class="top-bar">
             <a href="tel:+17735318473"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8473</span></a>
-            <a href="mailto:romanoroofingco@gmail.com"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
+            <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
         </div>
         <nav class="main-nav">
             <div class="logo-container">

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
     <header class="header">
         <div class="top-bar">
             <a href="tel:+17735318473"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8473</span></a>
-            <a href="mailto:romanoroofingco@gmail.com"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
+            <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
         </div>
         <nav class="main-nav">
             <div class="logo-container">
@@ -71,6 +71,7 @@
 <section id="about" class="about">
     <h2>About Us</h2>
     <p>We are a family-owned business with over 20 years of experience in providing high quality roofing services to our community. Our team is committed to delivering quality and reliability in every project. Over the years, we've built a reputation for professionalism and craftsmanship. Our customers trust us for all their roofing needs, from minor repairs to complete roof replacements. We use the highest quality materials and cutting-edge techniques to ensure every roof is durable, efficient, and built to last. We stand behind our work with a satisfaction guarantee and are proud to serve both residential and commercial properties across Chicagoland.</p>
+    <a href="careers.html" class="btn careers-btn">Careers</a>
 </section>
 
     <!-- Solutions Section -->

--- a/roof-installation.html
+++ b/roof-installation.html
@@ -20,7 +20,7 @@
     <header class="header">
         <div class="top-bar">
             <a href="tel:+17735318473"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8473</span></a>
-            <a href="mailto:romanoroofingco@gmail.com"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
+            <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
         </div>
         <nav class="main-nav">
             <div class="logo-container">

--- a/roof-repair.html
+++ b/roof-repair.html
@@ -20,7 +20,7 @@
     <header class="header">
         <div class="top-bar">
             <a href="tel:+17735318473"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8473</span></a>
-            <a href="mailto:romanoroofingco@gmail.com"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
+            <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
         </div>
         <nav class="main-nav">
             <div class="logo-container">

--- a/scripts.js
+++ b/scripts.js
@@ -108,4 +108,12 @@ document.addEventListener("DOMContentLoaded", function () {
         imageWidth = carouselImages[0].clientWidth + 20;
         updateCarousel();  // Recalculate and update the transform position
     });
+
+    // Ensure mailto links trigger email client on desktop
+    const emailLinks = document.querySelectorAll('a.email-link');
+    emailLinks.forEach(link => {
+        link.addEventListener('click', function () {
+            window.location.href = this.href;
+        });
+    });
 });

--- a/service-area.html
+++ b/service-area.html
@@ -20,7 +20,7 @@
     <header class="header">
         <div class="top-bar">
             <a href="tel:+17735318473"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8473</span></a>
-            <a href="mailto:romanoroofingco@gmail.com"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
+            <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
         </div>
         <nav class="main-nav">
             <div class="logo-container">

--- a/siding.html
+++ b/siding.html
@@ -20,7 +20,7 @@
     <header class="header">
         <div class="top-bar">
             <a href="tel:+17735318473"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8473</span></a>
-            <a href="mailto:romanoroofingco@gmail.com"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
+            <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
         </div>
         <nav class="main-nav">
             <div class="logo-container">

--- a/styles.css
+++ b/styles.css
@@ -403,6 +403,52 @@ ul {
 .service-detail .service-icon {
     color: #FF5733;
 }
+
+/* Service detail table styling */
+.service-detail table {
+    width: 100%;
+    max-width: 800px;
+    margin: 20px auto;
+    border-collapse: collapse;
+}
+
+.service-detail th,
+.service-detail td {
+    border: 1px solid #ddd;
+    padding: 8px;
+    text-align: left;
+}
+
+/* Careers section styling */
+.careers-section .careers-image {
+    width: 100%;
+    max-width: 600px;
+    display: block;
+    margin: 20px auto;
+}
+
+.careers-section ul {
+    list-style: disc;
+    max-width: 800px;
+    margin: 20px auto;
+    text-align: left;
+    padding-left: 20px;
+}
+
+/* Orange careers button */
+.btn.careers-btn {
+    background: #FF5733;
+    color: #fff;
+    padding: 10px 20px;
+    border-radius: 5px;
+    cursor: pointer;
+    display: inline-block;
+    margin-top: 20px;
+}
+
+.btn.careers-btn:hover {
+    background: #e14f2d;
+}
 /* Carousel styling */
 .carousel-container {
     display: flex;


### PR DESCRIPTION
## Summary
- Style service-area table with borders for clarity
- Ensure email icon opens default mail client on desktop
- Add Careers page and link from About section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689675e024548321a4f90199fa4238df