### PR TITLE
Add service area icon and center careers content

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -51,7 +51,7 @@
     </header>
 
     <div id="mobile-bar" class="mobile-contact-bar">
-        <a href="service-area.html" class="service-area-link">Service Area</a>
+        <a href="service-area.html" class="service-area-link"><i class="fas fa-map-marker-alt service-icon"></i> Service Area</a>
         <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
     </div>
 

--- a/gutters.html
+++ b/gutters.html
@@ -51,7 +51,7 @@
     </header>
 
     <div id="mobile-bar" class="mobile-contact-bar">
-        <a href="service-area.html" class="service-area-link">Service Area</a>
+        <a href="service-area.html" class="service-area-link"><i class="fas fa-map-marker-alt service-icon"></i> Service Area</a>
         <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
 
     <!-- Mobile Contact Bar -->
     <div id="mobile-bar" class="mobile-contact-bar">
-        <a href="service-area.html" class="service-area-link">Service Area</a>
+        <a href="service-area.html" class="service-area-link"><i class="fas fa-map-marker-alt service-icon"></i> Service Area</a>
         <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
     </div>
 

--- a/roof-installation.html
+++ b/roof-installation.html
@@ -51,7 +51,7 @@
     </header>
 
     <div id="mobile-bar" class="mobile-contact-bar">
-        <a href="service-area.html" class="service-area-link">Service Area</a>
+        <a href="service-area.html" class="service-area-link"><i class="fas fa-map-marker-alt service-icon"></i> Service Area</a>
         <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
     </div>
 

--- a/roof-repair.html
+++ b/roof-repair.html
@@ -51,7 +51,7 @@
     </header>
 
     <div id="mobile-bar" class="mobile-contact-bar">
-        <a href="service-area.html" class="service-area-link">Service Area</a>
+        <a href="service-area.html" class="service-area-link"><i class="fas fa-map-marker-alt service-icon"></i> Service Area</a>
         <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
     </div>
 

--- a/service-area.html
+++ b/service-area.html
@@ -51,7 +51,7 @@
     </header>
 
     <div id="mobile-bar" class="mobile-contact-bar">
-        <a href="service-area.html" class="service-area-link">Service Area</a>
+        <a href="service-area.html" class="service-area-link"><i class="fas fa-map-marker-alt service-icon"></i> Service Area</a>
         <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
     </div>
 

--- a/siding.html
+++ b/siding.html
@@ -51,7 +51,7 @@
     </header>
 
     <div id="mobile-bar" class="mobile-contact-bar">
-        <a href="service-area.html" class="service-area-link">Service Area</a>
+        <a href="service-area.html" class="service-area-link"><i class="fas fa-map-marker-alt service-icon"></i> Service Area</a>
         <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -420,6 +420,10 @@ ul {
 }
 
 /* Careers section styling */
+.careers-section {
+    text-align: center;
+}
+
 .careers-section .careers-image {
     width: 100%;
     max-width: 600px;
@@ -428,11 +432,15 @@ ul {
 }
 
 .careers-section ul {
-    list-style: disc;
+    list-style: none;
     max-width: 800px;
     margin: 20px auto;
-    text-align: left;
-    padding-left: 20px;
+    padding-left: 0;
+    text-align: center;
+}
+
+.careers-section ul li {
+    margin: 10px 0;
 }
 
 /* Orange careers button */
@@ -619,6 +627,11 @@ body {
 .mobile-contact-bar a {
     color: white;
     transition: text-shadow 0.3s;
+}
+
+.mobile-contact-bar .service-icon {
+    color: #FF5733;
+    margin-right: 5px;
 }
 
 .mobile-contact-bar a:hover {


### PR DESCRIPTION
## Summary
- Add map-marker icon to Service Area link in mobile contact bar and style it orange.
- Center and stack content in Careers section for cleaner layout.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68967b2e043483218b8c0d8fb54bbef2