### PR TITLE
Center mobile logo and enlarge contact bar

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -71,7 +71,8 @@ ul {
 .logo-container {
     position: absolute;
     left: 50%;
-    transform: translateX(-50%);
+    top: 50%;
+    transform: translate(-50%, -50%);
     z-index: 10;
 }
 
@@ -620,7 +621,7 @@ body {
     color: white;
     display: flex;
     justify-content: space-around;
-    padding: 12px 0;
+    padding: 16px 0;
     z-index: 950; /* Ensure it is above other content */
 }
 
@@ -644,7 +645,7 @@ body {
 
 /* Padding for body to prevent the mobile contact bar from covering content */
 body {
-    padding-bottom: 70px; /* Make sure there's space for the mobile contact bar */
+    padding-bottom: 80px; /* Make sure there's space for the mobile contact bar */
 }
 
 /* Mobile responsiveness */


### PR DESCRIPTION
## Summary
- Center logo within header on mobile by vertically and horizontally centering `.logo-container`.
- Increase mobile contact bar padding for a taller tap-friendly bar and adjust body bottom spacing accordingly.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68968ce949f08321836012d8b322445a