### PR TITLE
Center logo and reposition navigation in header

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -28,12 +28,12 @@
             <a href="tel:+17735318473"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8473</span></a>
             <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
         </div>
+        <div class="logo-container">
+            <a href="index.html">
+                <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
+            </a>
+        </div>
         <nav class="main-nav">
-            <div class="logo-container">
-                <a href="index.html">
-                    <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
-                </a>
-            </div>
             <ul>
                 <li><a href="index.html#solutions">Solutions</a></li>
                 <li><a href="index.html#about">About Us</a></li>

--- a/gutters.html
+++ b/gutters.html
@@ -28,12 +28,12 @@
             <a href="tel:+17735318473"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8473</span></a>
             <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
         </div>
+        <div class="logo-container">
+            <a href="index.html">
+                <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
+            </a>
+        </div>
         <nav class="main-nav">
-            <div class="logo-container">
-                <a href="index.html">
-                    <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
-                </a>
-            </div>
             <ul>
                 <li><a href="index.html#solutions">Solutions</a></li>
                 <li><a href="index.html#about">About Us</a></li>

--- a/index.html
+++ b/index.html
@@ -34,13 +34,12 @@
             <a href="tel:+17735318473"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8473</span></a>
             <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
         </div>
+        <div class="logo-container">
+            <a href="https://romanoroofing.co">
+                <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
+            </a>
+        </div>
         <nav class="main-nav">
-            <div class="logo-container">
-    <a href="https://romanoroofing.co">
-        <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
-    </a>
-</div>
-
             <ul>
                 <li><a href="#solutions">Solutions</a></li>
                 <li><a href="#about">About Us</a></li>

--- a/roof-installation.html
+++ b/roof-installation.html
@@ -28,12 +28,12 @@
             <a href="tel:+17735318473"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8473</span></a>
             <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
         </div>
+        <div class="logo-container">
+            <a href="index.html">
+                <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
+            </a>
+        </div>
         <nav class="main-nav">
-            <div class="logo-container">
-                <a href="index.html">
-                    <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
-                </a>
-            </div>
             <ul>
                 <li><a href="index.html#solutions">Solutions</a></li>
                 <li><a href="index.html#about">About Us</a></li>

--- a/roof-repair.html
+++ b/roof-repair.html
@@ -28,12 +28,12 @@
             <a href="tel:+17735318473"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8473</span></a>
             <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
         </div>
+        <div class="logo-container">
+            <a href="index.html">
+                <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
+            </a>
+        </div>
         <nav class="main-nav">
-            <div class="logo-container">
-                <a href="index.html">
-                    <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
-                </a>
-            </div>
             <ul>
                 <li><a href="index.html#solutions">Solutions</a></li>
                 <li><a href="index.html#about">About Us</a></li>

--- a/service-area.html
+++ b/service-area.html
@@ -28,12 +28,12 @@
             <a href="tel:+17735318473"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8473</span></a>
             <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
         </div>
+        <div class="logo-container">
+            <a href="index.html">
+                <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
+            </a>
+        </div>
         <nav class="main-nav">
-            <div class="logo-container">
-                <a href="index.html">
-                    <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
-                </a>
-            </div>
             <ul>
                 <li><a href="index.html#solutions">Solutions</a></li>
                 <li><a href="index.html#about">About Us</a></li>

--- a/siding.html
+++ b/siding.html
@@ -28,12 +28,12 @@
             <a href="tel:+17735318473"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8473</span></a>
             <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
         </div>
+        <div class="logo-container">
+            <a href="index.html">
+                <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
+            </a>
+        </div>
         <nav class="main-nav">
-            <div class="logo-container">
-                <a href="index.html">
-                    <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
-                </a>
-            </div>
             <ul>
                 <li><a href="index.html#solutions">Solutions</a></li>
                 <li><a href="index.html#about">About Us</a></li>

--- a/styles.css
+++ b/styles.css
@@ -32,12 +32,13 @@ ul {
 }
 
 /* Header */
+
 .header {
     background: #FF5733;
     color: #fff;
-    padding: 20px 20px;
+    padding: 25px 20px;
     display: flex;
-    justify-content: space-between;
+    flex-direction: column;
     align-items: center;
     position: fixed;
     top: 0;
@@ -47,10 +48,11 @@ ul {
 }
 
 .top-bar {
-    flex: 1;
+    width: 100%;
     display: flex;
     align-items: center;
-    justify-content: flex-start;
+    justify-content: center;
+    gap: 20px;
     white-space: nowrap;
 }
 
@@ -68,28 +70,39 @@ ul {
     display: none;
 }
 
+
 .logo-container {
-    position: absolute;
-    left: 50%;
-    top: 50%;
-    transform: translate(-50%, -50%);
-    z-index: 10;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin: 10px 0;
 }
 
 .logo {
     max-height: 50px;
+    display: block;
 }
 
 .main-nav {
-    flex: 2;
+    width: 100%;
     display: flex;
-    justify-content: flex-end;
+    justify-content: center;
     align-items: center;
+    position: relative;
+    min-height: 40px;
 }
 
 .main-nav ul {
     display: flex;
-    margin-right: 20px;
+    margin: 0;
+}
+
+.hamburger {
+    position: absolute;
+    right: 20px;
+    top: 50%;
+    transform: translateY(-50%);
 }
 
 .main-nav ul li a {
@@ -743,7 +756,7 @@ body {
     }
 
     .header {
-        padding: 40px 20px;
+        padding: 50px 20px;
     }
 
     .logo {


### PR DESCRIPTION
## Summary
- Center logo on all screen sizes and stack navigation beneath it
- Expand orange header padding for a more spacious layout
- Center top-bar content and ensure mobile menu remains accessible

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68968ff61a68832183282cb5526ff737