### PR TITLE
Configure EmailJS for contact form

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,6 +194,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@emailjs/browser@3/dist/email.min.js"></script>
     <script src="scripts.js"></script>
 </body>
 </html>

--- a/scripts.js
+++ b/scripts.js
@@ -1,7 +1,8 @@
 document.addEventListener("DOMContentLoaded", function () {
-    // Initialize EmailJS with your user ID
+    // Initialize EmailJS
     if (typeof emailjs !== 'undefined') {
-        emailjs.init('DZojhFh7ITojx93eX');  // Replace with your actual EmailJS user ID
+        // Initialize EmailJS with your public key
+        emailjs.init('Y-XtDjX-x7GuFRumI');
     }
 
     const contactForm = document.getElementById('contact-form');
@@ -10,7 +11,7 @@ document.addEventListener("DOMContentLoaded", function () {
         contactForm.addEventListener('submit', function (event) {
             event.preventDefault();
 
-            emailjs.sendForm('service_czd6kd3', 'template_0h89c3i', this)
+            emailjs.sendForm('service_ae5o7qq', 'template_rd9i0ip', this)
                 .then(function (response) {
                     // Show a "Message Sent!" popup (without refreshing the page)
                     alert('Message Sent!');


### PR DESCRIPTION
## Summary
- Load EmailJS SDK and initialize with new public key
- Send contact form submissions through EmailJS service `service_ae5o7qq` and template `template_rd9i0ip`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689691ddaa30832183aa7e1092f7958e