### PR TITLE
Revise header contact icons and mobile menu

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -24,10 +24,6 @@
 </head>
 <body>
     <header class="header">
-        <div class="top-bar">
-            <a href="tel:+17735318473"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8473</span></a>
-            <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
-        </div>
         <div class="logo-container">
             <a href="index.html">
                 <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
@@ -42,24 +38,24 @@
                 <li><a href="index.html#contact">Contact</a></li>
                 <li><a href="careers.html">Careers</a></li>
             </ul>
-            <div class="hamburger"><i class="fas fa-bars"></i></div>
-            <div class="mobile-menu">
-                <ul>
-                    <li><a href="index.html#solutions">Solutions</a></li>
-                    <li><a href="index.html#about">About Us</a></li>
-                    <li><a href="index.html#projects">Projects</a></li>
-                    <li><a href="index.html#testimonials">Testimonials</a></li>
-                    <li><a href="index.html#contact">Contact</a></li>
-                    <li><a href="careers.html">Careers</a></li>
-                </ul>
-            </div>
         </nav>
+        <div class="contact-icons">
+            <a href="tel:+17735318473"><i class="fas fa-phone"></i></a>
+            <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a>
+        </div>
+        <div class="hamburger"><i class="fas fa-bars"></i></div>
+        <div class="mobile-menu">
+            <ul>
+                <li><a href="index.html#solutions">Solutions</a></li>
+                <li><a href="index.html#about">About Us</a></li>
+                <li><a href="index.html#projects">Projects</a></li>
+                <li><a href="index.html#testimonials">Testimonials</a></li>
+                <li><a href="index.html#contact">Contact</a></li>
+                <li><a href="careers.html">Careers</a></li>
+                <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> romanoroofingco@gmail.com</a></li>
+            </ul>
+        </div>
     </header>
-
-    <div id="mobile-bar" class="mobile-contact-bar">
-        <a href="service-area.html" class="service-area-link"><i class="fas fa-map-marker-alt service-icon"></i> Service Area</a>
-        <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
-    </div>
 
     <section class="service-detail careers-section">
         <h2>Join Our Team!</h2>

--- a/gutters.html
+++ b/gutters.html
@@ -24,10 +24,6 @@
 </head>
 <body>
     <header class="header">
-        <div class="top-bar">
-            <a href="tel:+17735318473"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8473</span></a>
-            <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
-        </div>
         <div class="logo-container">
             <a href="index.html">
                 <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
@@ -42,24 +38,24 @@
                 <li><a href="index.html#contact">Contact</a></li>
                 <li><a href="careers.html">Careers</a></li>
             </ul>
-            <div class="hamburger"><i class="fas fa-bars"></i></div>
-            <div class="mobile-menu">
-                <ul>
-                    <li><a href="index.html#solutions">Solutions</a></li>
-                    <li><a href="index.html#about">About Us</a></li>
-                    <li><a href="index.html#projects">Projects</a></li>
-                    <li><a href="index.html#testimonials">Testimonials</a></li>
-                    <li><a href="index.html#contact">Contact</a></li>
-                    <li><a href="careers.html">Careers</a></li>
-                </ul>
-            </div>
         </nav>
+        <div class="contact-icons">
+            <a href="tel:+17735318473"><i class="fas fa-phone"></i></a>
+            <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a>
+        </div>
+        <div class="hamburger"><i class="fas fa-bars"></i></div>
+        <div class="mobile-menu">
+            <ul>
+                <li><a href="index.html#solutions">Solutions</a></li>
+                <li><a href="index.html#about">About Us</a></li>
+                <li><a href="index.html#projects">Projects</a></li>
+                <li><a href="index.html#testimonials">Testimonials</a></li>
+                <li><a href="index.html#contact">Contact</a></li>
+                <li><a href="careers.html">Careers</a></li>
+                <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> romanoroofingco@gmail.com</a></li>
+            </ul>
+        </div>
     </header>
-
-    <div id="mobile-bar" class="mobile-contact-bar">
-        <a href="service-area.html" class="service-area-link"><i class="fas fa-map-marker-alt service-icon"></i> Service Area</a>
-        <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
-    </div>
 
     <section class="service-detail">
         <h2><i class="fas fa-water service-icon"></i> Gutters</h2>

--- a/index.html
+++ b/index.html
@@ -30,10 +30,6 @@
 <body>
     <!-- Header -->
     <header class="header">
-        <div class="top-bar">
-            <a href="tel:+17735318473"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8473</span></a>
-            <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
-        </div>
         <div class="logo-container">
             <a href="https://romanoroofing.co">
                 <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
@@ -48,25 +44,24 @@
                 <li><a href="#contact">Contact</a></li>
                 <li><a href="careers.html">Careers</a></li>
             </ul>
-            <div class="hamburger"><i class="fas fa-bars"></i></div>
-            <div class="mobile-menu">
-                <ul>
-                    <li><a href="#solutions">Solutions</a></li>
-                    <li><a href="#about">About Us</a></li>
-                    <li><a href="#projects">Projects</a></li>
-                    <li><a href="#testimonials">Testimonials</a></li>
-                    <li><a href="#contact">Contact</a></li>
-                    <li><a href="careers.html">Careers</a></li>
-                </ul>
-            </div>
         </nav>
+        <div class="contact-icons">
+            <a href="tel:+17735318473"><i class="fas fa-phone"></i></a>
+            <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a>
+        </div>
+        <div class="hamburger"><i class="fas fa-bars"></i></div>
+        <div class="mobile-menu">
+            <ul>
+                <li><a href="#solutions">Solutions</a></li>
+                <li><a href="#about">About Us</a></li>
+                <li><a href="#projects">Projects</a></li>
+                <li><a href="#testimonials">Testimonials</a></li>
+                <li><a href="#contact">Contact</a></li>
+                <li><a href="careers.html">Careers</a></li>
+                <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> romanoroofingco@gmail.com</a></li>
+            </ul>
+        </div>
     </header>
-
-    <!-- Mobile Contact Bar -->
-    <div id="mobile-bar" class="mobile-contact-bar">
-        <a href="service-area.html" class="service-area-link"><i class="fas fa-map-marker-alt service-icon"></i> Service Area</a>
-        <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
-    </div>
 
     <!-- Main Banner -->
     <section class="main-banner">

--- a/roof-installation.html
+++ b/roof-installation.html
@@ -24,10 +24,6 @@
 </head>
 <body>
     <header class="header">
-        <div class="top-bar">
-            <a href="tel:+17735318473"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8473</span></a>
-            <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
-        </div>
         <div class="logo-container">
             <a href="index.html">
                 <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
@@ -42,24 +38,24 @@
                 <li><a href="index.html#contact">Contact</a></li>
                 <li><a href="careers.html">Careers</a></li>
             </ul>
-            <div class="hamburger"><i class="fas fa-bars"></i></div>
-            <div class="mobile-menu">
-                <ul>
-                    <li><a href="index.html#solutions">Solutions</a></li>
-                    <li><a href="index.html#about">About Us</a></li>
-                    <li><a href="index.html#projects">Projects</a></li>
-                    <li><a href="index.html#testimonials">Testimonials</a></li>
-                    <li><a href="index.html#contact">Contact</a></li>
-                    <li><a href="careers.html">Careers</a></li>
-                </ul>
-            </div>
         </nav>
+        <div class="contact-icons">
+            <a href="tel:+17735318473"><i class="fas fa-phone"></i></a>
+            <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a>
+        </div>
+        <div class="hamburger"><i class="fas fa-bars"></i></div>
+        <div class="mobile-menu">
+            <ul>
+                <li><a href="index.html#solutions">Solutions</a></li>
+                <li><a href="index.html#about">About Us</a></li>
+                <li><a href="index.html#projects">Projects</a></li>
+                <li><a href="index.html#testimonials">Testimonials</a></li>
+                <li><a href="index.html#contact">Contact</a></li>
+                <li><a href="careers.html">Careers</a></li>
+                <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> romanoroofingco@gmail.com</a></li>
+            </ul>
+        </div>
     </header>
-
-    <div id="mobile-bar" class="mobile-contact-bar">
-        <a href="service-area.html" class="service-area-link"><i class="fas fa-map-marker-alt service-icon"></i> Service Area</a>
-        <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
-    </div>
 
     <section class="service-detail">
         <h2><i class="fas fa-home service-icon"></i> Roof Installation</h2>

--- a/roof-repair.html
+++ b/roof-repair.html
@@ -24,10 +24,6 @@
 </head>
 <body>
     <header class="header">
-        <div class="top-bar">
-            <a href="tel:+17735318473"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8473</span></a>
-            <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
-        </div>
         <div class="logo-container">
             <a href="index.html">
                 <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
@@ -42,24 +38,24 @@
                 <li><a href="index.html#contact">Contact</a></li>
                 <li><a href="careers.html">Careers</a></li>
             </ul>
-            <div class="hamburger"><i class="fas fa-bars"></i></div>
-            <div class="mobile-menu">
-                <ul>
-                    <li><a href="index.html#solutions">Solutions</a></li>
-                    <li><a href="index.html#about">About Us</a></li>
-                    <li><a href="index.html#projects">Projects</a></li>
-                    <li><a href="index.html#testimonials">Testimonials</a></li>
-                    <li><a href="index.html#contact">Contact</a></li>
-                    <li><a href="careers.html">Careers</a></li>
-                </ul>
-            </div>
         </nav>
+        <div class="contact-icons">
+            <a href="tel:+17735318473"><i class="fas fa-phone"></i></a>
+            <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a>
+        </div>
+        <div class="hamburger"><i class="fas fa-bars"></i></div>
+        <div class="mobile-menu">
+            <ul>
+                <li><a href="index.html#solutions">Solutions</a></li>
+                <li><a href="index.html#about">About Us</a></li>
+                <li><a href="index.html#projects">Projects</a></li>
+                <li><a href="index.html#testimonials">Testimonials</a></li>
+                <li><a href="index.html#contact">Contact</a></li>
+                <li><a href="careers.html">Careers</a></li>
+                <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> romanoroofingco@gmail.com</a></li>
+            </ul>
+        </div>
     </header>
-
-    <div id="mobile-bar" class="mobile-contact-bar">
-        <a href="service-area.html" class="service-area-link"><i class="fas fa-map-marker-alt service-icon"></i> Service Area</a>
-        <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
-    </div>
 
     <section class="service-detail">
         <h2><i class="fas fa-toolbox service-icon"></i> Roof Repair</h2>

--- a/scripts.js
+++ b/scripts.js
@@ -22,22 +22,6 @@ document.addEventListener("DOMContentLoaded", function () {
         });
     }
 
-    // Sticky mobile bar logic
-    const mobileBar = document.getElementById('mobile-bar');
-    const stickyOffset = mobileBar ? mobileBar.offsetTop : 0;
-
-    function stickyMobileBar() {
-        if (window.pageYOffset >= stickyOffset) {
-            mobileBar.classList.add('sticky');
-        } else {
-            mobileBar.classList.remove('sticky');
-        }
-    }
-
-    window.onscroll = function () {
-        stickyMobileBar();
-    };
-
     // Hamburger menu functionality
     const mobileMenu = document.querySelector('.mobile-menu');
     const hamburger = document.querySelector('.hamburger');

--- a/service-area.html
+++ b/service-area.html
@@ -24,10 +24,6 @@
 </head>
 <body>
     <header class="header">
-        <div class="top-bar">
-            <a href="tel:+17735318473"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8473</span></a>
-            <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
-        </div>
         <div class="logo-container">
             <a href="index.html">
                 <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
@@ -42,24 +38,24 @@
                 <li><a href="index.html#contact">Contact</a></li>
                 <li><a href="careers.html">Careers</a></li>
             </ul>
-            <div class="hamburger"><i class="fas fa-bars"></i></div>
-            <div class="mobile-menu">
-                <ul>
-                    <li><a href="index.html#solutions">Solutions</a></li>
-                    <li><a href="index.html#about">About Us</a></li>
-                    <li><a href="index.html#projects">Projects</a></li>
-                    <li><a href="index.html#testimonials">Testimonials</a></li>
-                    <li><a href="index.html#contact">Contact</a></li>
-                    <li><a href="careers.html">Careers</a></li>
-                </ul>
-            </div>
         </nav>
+        <div class="contact-icons">
+            <a href="tel:+17735318473"><i class="fas fa-phone"></i></a>
+            <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a>
+        </div>
+        <div class="hamburger"><i class="fas fa-bars"></i></div>
+        <div class="mobile-menu">
+            <ul>
+                <li><a href="index.html#solutions">Solutions</a></li>
+                <li><a href="index.html#about">About Us</a></li>
+                <li><a href="index.html#projects">Projects</a></li>
+                <li><a href="index.html#testimonials">Testimonials</a></li>
+                <li><a href="index.html#contact">Contact</a></li>
+                <li><a href="careers.html">Careers</a></li>
+                <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> romanoroofingco@gmail.com</a></li>
+            </ul>
+        </div>
     </header>
-
-    <div id="mobile-bar" class="mobile-contact-bar">
-        <a href="service-area.html" class="service-area-link"><i class="fas fa-map-marker-alt service-icon"></i> Service Area</a>
-        <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
-    </div>
 
     <section class="service-detail">
         <h2><i class="fas fa-map-marker-alt service-icon"></i> Our Service Area</h2>

--- a/siding.html
+++ b/siding.html
@@ -24,10 +24,6 @@
 </head>
 <body>
     <header class="header">
-        <div class="top-bar">
-            <a href="tel:+17735318473"><i class="fas fa-phone"></i> <span class="contact-text">Call Us: (773) 531-8473</span></a>
-            <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> <span class="contact-text">romanoroofingco@gmail.com</span></a>
-        </div>
         <div class="logo-container">
             <a href="index.html">
                 <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
@@ -42,24 +38,24 @@
                 <li><a href="index.html#contact">Contact</a></li>
                 <li><a href="careers.html">Careers</a></li>
             </ul>
-            <div class="hamburger"><i class="fas fa-bars"></i></div>
-            <div class="mobile-menu">
-                <ul>
-                    <li><a href="index.html#solutions">Solutions</a></li>
-                    <li><a href="index.html#about">About Us</a></li>
-                    <li><a href="index.html#projects">Projects</a></li>
-                    <li><a href="index.html#testimonials">Testimonials</a></li>
-                    <li><a href="index.html#contact">Contact</a></li>
-                    <li><a href="careers.html">Careers</a></li>
-                </ul>
-            </div>
         </nav>
+        <div class="contact-icons">
+            <a href="tel:+17735318473"><i class="fas fa-phone"></i></a>
+            <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a>
+        </div>
+        <div class="hamburger"><i class="fas fa-bars"></i></div>
+        <div class="mobile-menu">
+            <ul>
+                <li><a href="index.html#solutions">Solutions</a></li>
+                <li><a href="index.html#about">About Us</a></li>
+                <li><a href="index.html#projects">Projects</a></li>
+                <li><a href="index.html#testimonials">Testimonials</a></li>
+                <li><a href="index.html#contact">Contact</a></li>
+                <li><a href="careers.html">Careers</a></li>
+                <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> romanoroofingco@gmail.com</a></li>
+            </ul>
+        </div>
     </header>
-
-    <div id="mobile-bar" class="mobile-contact-bar">
-        <a href="service-area.html" class="service-area-link"><i class="fas fa-map-marker-alt service-icon"></i> Service Area</a>
-        <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
-    </div>
 
     <section class="service-detail">
         <h2><i class="fas fa-paint-roller service-icon"></i> Siding</h2>

--- a/styles.css
+++ b/styles.css
@@ -20,7 +20,7 @@ body {
     line-height: 1;
     font-family: 'Open Sans', sans-serif;
     position: relative;
-    padding-bottom: 100px;
+    padding-bottom: 0;
     overflow-x: hidden;
 }
 a {
@@ -46,30 +46,6 @@ ul {
     width: 100%;
     z-index: 1000;
 }
-
-.top-bar {
-    width: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 20px;
-    white-space: nowrap;
-}
-
-.top-bar a {
-    color: #fff;
-    padding: 0 10px;
-    font-size: 0.9em;
-    transition: text-shadow 0.3s;
-}
-
-.top-bar a:hover {
-    text-shadow: 0 0 5px #fff, 0 0 10px #fff;
-}
-.top-bar .contact-text {
-    display: none;
-}
-
 
 .logo-container {
     width: 100%;
@@ -99,10 +75,7 @@ ul {
 }
 
 .hamburger {
-    position: absolute;
-    right: 20px;
-    top: 50%;
-    transform: translateY(-50%);
+    display: none;
 }
 
 .main-nav ul li a {
@@ -115,13 +88,29 @@ ul {
     text-shadow: 0 0 5px #fff, 0 0 10px #fff;
 }
 
-.top-bar a i,
+.contact-icons a i,
 .hamburger i {
     transition: text-shadow 0.3s;
 }
 
-.top-bar a:hover i,
+.contact-icons a:hover i,
 .hamburger:hover i {
+    text-shadow: 0 0 5px #fff, 0 0 10px #fff;
+}
+
+.contact-icons {
+    display: flex;
+    gap: 20px;
+    margin-top: 10px;
+}
+
+.contact-icons a {
+    color: #fff;
+    font-size: 1.2em;
+    transition: text-shadow 0.3s;
+}
+
+.contact-icons a:hover {
     text-shadow: 0 0 5px #fff, 0 0 10px #fff;
 }
 
@@ -624,54 +613,13 @@ body {
     margin-top: 20px; /* Optional: Adjust if you want a bit of separation */
 }
 
-/* Mobile Contact Bar */
-.mobile-contact-bar {
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    background: #333;
-    color: white;
-    display: flex;
-    justify-content: space-around;
-    padding: 16px 0;
-    z-index: 950; /* Ensure it is above other content */
-}
-
-.mobile-contact-bar a {
-    color: white;
-    transition: text-shadow 0.3s;
-}
-
-.mobile-contact-bar .service-icon {
-    color: #FF5733;
-    margin-right: 5px;
-}
-
-.mobile-contact-bar a:hover {
-    text-shadow: 0 0 5px #fff, 0 0 10px #fff;
-}
-
-.sticky {
-    display: flex;
-}
-
-/* Padding for body to prevent the mobile contact bar from covering content */
-body {
-    padding-bottom: 80px; /* Make sure there's space for the mobile contact bar */
-}
-
 /* Mobile responsiveness */
 @media (max-width: 768px) {
-    .top-bar .contact-text {
+    .main-nav {
         display: none;
     }
 
-    .top-bar a i {
-        font-size: 1.2em;
-    }
-
-    .main-nav ul {
+    .contact-icons {
         display: none;
     }
 
@@ -681,11 +629,7 @@ body {
         cursor: pointer;
         font-size: 2em;
         color: #fff;
-        position: fixed; /* Keeps it fixed */
-        right: 20px;
-        top: 10px; /* Move it up to align better with other icons */
-        z-index: 2000;
-        padding: 10px;
+        margin-top: 10px;
     }
 
     /* Mobile Menu - Full screen transparent box */
@@ -730,11 +674,11 @@ body {
 
     .main-banner {
         margin-top: 0;
-        padding-top: 100px; /* Add breathing room above quote on mobile */
+        padding-top: 160px; /* Ensure quote is visible below fixed header */
     }
 
     .service-detail {
-        padding-top: 100px;
+        padding-top: 160px;
     }
 
     .service-detail h2 {


### PR DESCRIPTION
## Summary
- Move phone and email icons beneath desktop navigation
- Show email only within mobile menu and center hamburger under logo
- Remove mobile contact bar and prevent hero content from being covered

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689693b8de908321914925d75e7f7273