### PR TITLE
Restore bottom mobile bar and simplify header icons

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -39,10 +39,6 @@
                 <li><a href="careers.html">Careers</a></li>
             </ul>
         </nav>
-        <div class="contact-icons">
-            <a href="tel:+17735318473"><i class="fas fa-phone"></i></a>
-            <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a>
-        </div>
         <div class="hamburger"><i class="fas fa-bars"></i></div>
         <div class="mobile-menu">
             <ul>
@@ -52,10 +48,15 @@
                 <li><a href="index.html#testimonials">Testimonials</a></li>
                 <li><a href="index.html#contact">Contact</a></li>
                 <li><a href="careers.html">Careers</a></li>
-                <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> romanoroofingco@gmail.com</a></li>
+                <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a></li>
             </ul>
         </div>
     </header>
+
+    <div id="mobile-bar" class="mobile-contact-bar">
+        <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
+        <a href="index.html#contact" class="btn">Get a Free Quote</a>
+    </div>
 
     <section class="service-detail careers-section">
         <h2>Join Our Team!</h2>

--- a/gutters.html
+++ b/gutters.html
@@ -39,10 +39,6 @@
                 <li><a href="careers.html">Careers</a></li>
             </ul>
         </nav>
-        <div class="contact-icons">
-            <a href="tel:+17735318473"><i class="fas fa-phone"></i></a>
-            <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a>
-        </div>
         <div class="hamburger"><i class="fas fa-bars"></i></div>
         <div class="mobile-menu">
             <ul>
@@ -52,10 +48,15 @@
                 <li><a href="index.html#testimonials">Testimonials</a></li>
                 <li><a href="index.html#contact">Contact</a></li>
                 <li><a href="careers.html">Careers</a></li>
-                <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> romanoroofingco@gmail.com</a></li>
+                <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a></li>
             </ul>
         </div>
     </header>
+
+    <div id="mobile-bar" class="mobile-contact-bar">
+        <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
+        <a href="index.html#contact" class="btn">Get a Free Quote</a>
+    </div>
 
     <section class="service-detail">
         <h2><i class="fas fa-water service-icon"></i> Gutters</h2>

--- a/index.html
+++ b/index.html
@@ -46,10 +46,6 @@
                 <li><a href="careers.html">Careers</a></li>
             </ul>
         </nav>
-        <div class="contact-icons">
-            <a href="tel:+17735318473"><i class="fas fa-phone"></i></a>
-            <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a>
-        </div>
     </header>
     <div class="mobile-menu">
         <div class="close-menu">&times;</div>
@@ -60,17 +56,19 @@
             <li><a href="#testimonials">Testimonials</a></li>
             <li><a href="#contact">Contact</a></li>
             <li><a href="careers.html">Careers</a></li>
-            <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> romanoroofingco@gmail.com</a></li>
+            <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a></li>
         </ul>
+    </div>
+
+    <div id="mobile-bar" class="mobile-contact-bar">
+        <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
+        <a href="#contact" class="btn">Get a Free Quote</a>
     </div>
 
     <!-- Main Banner -->
     <section class="main-banner">
-        <img src="1.jpg" alt="Roofing team at work" class="banner-image">
-        <div class="banner-content">
-            <p>"Delivering top-tier roofing solutions across Chicagoland for over two decades."</p>
-            <a href="#contact" class="btn primary-btn">Contact Us</a>
-        </div>
+        <p>"Delivering top-tier roofing solutions across Chicagoland for over two decades."</p>
+        <a href="#contact" class="btn primary-btn">Contact Us</a>
     </section>
     
     <!-- About Section -->

--- a/roof-installation.html
+++ b/roof-installation.html
@@ -39,10 +39,6 @@
                 <li><a href="careers.html">Careers</a></li>
             </ul>
         </nav>
-        <div class="contact-icons">
-            <a href="tel:+17735318473"><i class="fas fa-phone"></i></a>
-            <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a>
-        </div>
         <div class="hamburger"><i class="fas fa-bars"></i></div>
         <div class="mobile-menu">
             <ul>
@@ -52,10 +48,15 @@
                 <li><a href="index.html#testimonials">Testimonials</a></li>
                 <li><a href="index.html#contact">Contact</a></li>
                 <li><a href="careers.html">Careers</a></li>
-                <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> romanoroofingco@gmail.com</a></li>
+                <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a></li>
             </ul>
         </div>
     </header>
+
+    <div id="mobile-bar" class="mobile-contact-bar">
+        <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
+        <a href="index.html#contact" class="btn">Get a Free Quote</a>
+    </div>
 
     <section class="service-detail">
         <h2><i class="fas fa-home service-icon"></i> Roof Installation</h2>

--- a/roof-repair.html
+++ b/roof-repair.html
@@ -39,10 +39,6 @@
                 <li><a href="careers.html">Careers</a></li>
             </ul>
         </nav>
-        <div class="contact-icons">
-            <a href="tel:+17735318473"><i class="fas fa-phone"></i></a>
-            <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a>
-        </div>
         <div class="hamburger"><i class="fas fa-bars"></i></div>
         <div class="mobile-menu">
             <ul>
@@ -52,10 +48,15 @@
                 <li><a href="index.html#testimonials">Testimonials</a></li>
                 <li><a href="index.html#contact">Contact</a></li>
                 <li><a href="careers.html">Careers</a></li>
-                <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> romanoroofingco@gmail.com</a></li>
+                <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a></li>
             </ul>
         </div>
     </header>
+
+    <div id="mobile-bar" class="mobile-contact-bar">
+        <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
+        <a href="index.html#contact" class="btn">Get a Free Quote</a>
+    </div>
 
     <section class="service-detail">
         <h2><i class="fas fa-toolbox service-icon"></i> Roof Repair</h2>

--- a/service-area.html
+++ b/service-area.html
@@ -39,10 +39,6 @@
                 <li><a href="careers.html">Careers</a></li>
             </ul>
         </nav>
-        <div class="contact-icons">
-            <a href="tel:+17735318473"><i class="fas fa-phone"></i></a>
-            <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a>
-        </div>
         <div class="hamburger"><i class="fas fa-bars"></i></div>
         <div class="mobile-menu">
             <ul>
@@ -52,10 +48,15 @@
                 <li><a href="index.html#testimonials">Testimonials</a></li>
                 <li><a href="index.html#contact">Contact</a></li>
                 <li><a href="careers.html">Careers</a></li>
-                <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> romanoroofingco@gmail.com</a></li>
+                <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a></li>
             </ul>
         </div>
     </header>
+
+    <div id="mobile-bar" class="mobile-contact-bar">
+        <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
+        <a href="index.html#contact" class="btn">Get a Free Quote</a>
+    </div>
 
     <section class="service-detail">
         <h2><i class="fas fa-map-marker-alt service-icon"></i> Our Service Area</h2>

--- a/siding.html
+++ b/siding.html
@@ -39,10 +39,6 @@
                 <li><a href="careers.html">Careers</a></li>
             </ul>
         </nav>
-        <div class="contact-icons">
-            <a href="tel:+17735318473"><i class="fas fa-phone"></i></a>
-            <a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a>
-        </div>
         <div class="hamburger"><i class="fas fa-bars"></i></div>
         <div class="mobile-menu">
             <ul>
@@ -52,10 +48,15 @@
                 <li><a href="index.html#testimonials">Testimonials</a></li>
                 <li><a href="index.html#contact">Contact</a></li>
                 <li><a href="careers.html">Careers</a></li>
-                <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i> romanoroofingco@gmail.com</a></li>
+                <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a></li>
             </ul>
         </div>
     </header>
+
+    <div id="mobile-bar" class="mobile-contact-bar">
+        <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
+        <a href="index.html#contact" class="btn">Get a Free Quote</a>
+    </div>
 
     <section class="service-detail">
         <h2><i class="fas fa-paint-roller service-icon"></i> Siding</h2>

--- a/styles.css
+++ b/styles.css
@@ -37,9 +37,10 @@ ul {
 .header {
     background: #FF5733;
     color: #fff;
-    padding: 15px 20px;
+    padding: 20px 20px;
     display: flex;
     align-items: center;
+    justify-content: space-between;
     position: fixed;
     top: 0;
     left: 0;
@@ -65,26 +66,11 @@ ul {
     cursor: pointer;
 }
 
-.contact-icons {
-    display: flex;
-    gap: 20px;
-    align-items: center;
-    margin-left: auto;
-}
-
-.contact-icons a {
-    color: #fff;
-    font-size: 1.5em;
+.hamburger i {
     transition: text-shadow 0.3s;
 }
 
-.hamburger i,
-.contact-icons a i {
-    transition: text-shadow 0.3s;
-}
-
-.hamburger:hover i,
-.contact-icons a:hover i {
+.hamburger:hover i {
     text-shadow: 0 0 5px #fff, 0 0 10px #fff;
 }
 
@@ -110,32 +96,26 @@ ul {
 
 /* Main Banner */
 .main-banner {
-    position: relative;
+    background: url('2.jpeg') no-repeat center center/cover;
     text-align: center;
+    padding: 60px 20px;
     color: #fff;
     font-family: 'Merriweather', serif;
+    position: relative;
 }
 
-.banner-image {
-    width: 100%;
-    height: auto;
-    display: block;
-}
-
-.banner-content {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-}
-
-.banner-content p {
+.main-banner p {
     font-size: 1.75em;
     margin-bottom: 30px;
     font-weight: 600;
     font-style: italic;
     color: #fff;
     text-shadow: 0 0 10px rgba(255, 87, 51, 0.6);
+}
+
+/* Mobile Contact Bar */
+.mobile-contact-bar {
+    display: none;
 }
 
 .btn.primary-btn {
@@ -673,6 +653,23 @@ body {
 @media (max-width: 768px) {
     .service-detail {
         padding: 60px 20px 40px;
+    }
+
+    .mobile-contact-bar {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        background: #333;
+        color: #fff;
+        display: flex;
+        justify-content: space-around;
+        padding: 10px 0;
+        z-index: 950;
+    }
+
+    body {
+        padding-bottom: 80px;
     }
 }
 


### PR DESCRIPTION
## Summary
- Bring back fixed mobile contact bar and make email icon-only in the mobile menu
- Remove phone/email icons from header and add extra padding for the logo
- Revert hero section to previous background image

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68969eb345cc8321abf66b9307038f69