### PR TITLE
Improve header layout and mobile navigation

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -24,12 +24,13 @@
 </head>
 <body>
     <header class="header">
+        <div class="hamburger"><i class="fas fa-bars"></i></div>
         <div class="logo-container">
             <a href="index.html">
                 <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
             </a>
         </div>
-        <nav class="main-nav">
+        <nav class="desktop-nav">
             <ul>
                 <li><a href="index.html#solutions">Solutions</a></li>
                 <li><a href="index.html#about">About Us</a></li>
@@ -39,19 +40,19 @@
                 <li><a href="careers.html">Careers</a></li>
             </ul>
         </nav>
-        <div class="hamburger"><i class="fas fa-bars"></i></div>
-        <div class="mobile-menu">
-            <ul>
-                <li><a href="index.html#solutions">Solutions</a></li>
-                <li><a href="index.html#about">About Us</a></li>
-                <li><a href="index.html#projects">Projects</a></li>
-                <li><a href="index.html#testimonials">Testimonials</a></li>
-                <li><a href="index.html#contact">Contact</a></li>
-                <li><a href="careers.html">Careers</a></li>
-                <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a></li>
-            </ul>
-        </div>
     </header>
+    <div class="mobile-menu">
+        <div class="close-menu">&times;</div>
+        <ul>
+            <li><a href="index.html#solutions">Solutions</a></li>
+            <li><a href="index.html#about">About Us</a></li>
+            <li><a href="index.html#projects">Projects</a></li>
+            <li><a href="index.html#testimonials">Testimonials</a></li>
+            <li><a href="index.html#contact">Contact</a></li>
+            <li><a href="careers.html">Careers</a></li>
+            <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a></li>
+        </ul>
+    </div>
 
     <div id="mobile-bar" class="mobile-contact-bar">
         <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>

--- a/gutters.html
+++ b/gutters.html
@@ -24,12 +24,13 @@
 </head>
 <body>
     <header class="header">
+        <div class="hamburger"><i class="fas fa-bars"></i></div>
         <div class="logo-container">
             <a href="index.html">
                 <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
             </a>
         </div>
-        <nav class="main-nav">
+        <nav class="desktop-nav">
             <ul>
                 <li><a href="index.html#solutions">Solutions</a></li>
                 <li><a href="index.html#about">About Us</a></li>
@@ -39,19 +40,19 @@
                 <li><a href="careers.html">Careers</a></li>
             </ul>
         </nav>
-        <div class="hamburger"><i class="fas fa-bars"></i></div>
-        <div class="mobile-menu">
-            <ul>
-                <li><a href="index.html#solutions">Solutions</a></li>
-                <li><a href="index.html#about">About Us</a></li>
-                <li><a href="index.html#projects">Projects</a></li>
-                <li><a href="index.html#testimonials">Testimonials</a></li>
-                <li><a href="index.html#contact">Contact</a></li>
-                <li><a href="careers.html">Careers</a></li>
-                <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a></li>
-            </ul>
-        </div>
     </header>
+    <div class="mobile-menu">
+        <div class="close-menu">&times;</div>
+        <ul>
+            <li><a href="index.html#solutions">Solutions</a></li>
+            <li><a href="index.html#about">About Us</a></li>
+            <li><a href="index.html#projects">Projects</a></li>
+            <li><a href="index.html#testimonials">Testimonials</a></li>
+            <li><a href="index.html#contact">Contact</a></li>
+            <li><a href="careers.html">Careers</a></li>
+            <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a></li>
+        </ul>
+    </div>
 
     <div id="mobile-bar" class="mobile-contact-bar">
         <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>

--- a/roof-installation.html
+++ b/roof-installation.html
@@ -24,12 +24,13 @@
 </head>
 <body>
     <header class="header">
+        <div class="hamburger"><i class="fas fa-bars"></i></div>
         <div class="logo-container">
             <a href="index.html">
                 <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
             </a>
         </div>
-        <nav class="main-nav">
+        <nav class="desktop-nav">
             <ul>
                 <li><a href="index.html#solutions">Solutions</a></li>
                 <li><a href="index.html#about">About Us</a></li>
@@ -39,19 +40,19 @@
                 <li><a href="careers.html">Careers</a></li>
             </ul>
         </nav>
-        <div class="hamburger"><i class="fas fa-bars"></i></div>
-        <div class="mobile-menu">
-            <ul>
-                <li><a href="index.html#solutions">Solutions</a></li>
-                <li><a href="index.html#about">About Us</a></li>
-                <li><a href="index.html#projects">Projects</a></li>
-                <li><a href="index.html#testimonials">Testimonials</a></li>
-                <li><a href="index.html#contact">Contact</a></li>
-                <li><a href="careers.html">Careers</a></li>
-                <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a></li>
-            </ul>
-        </div>
     </header>
+    <div class="mobile-menu">
+        <div class="close-menu">&times;</div>
+        <ul>
+            <li><a href="index.html#solutions">Solutions</a></li>
+            <li><a href="index.html#about">About Us</a></li>
+            <li><a href="index.html#projects">Projects</a></li>
+            <li><a href="index.html#testimonials">Testimonials</a></li>
+            <li><a href="index.html#contact">Contact</a></li>
+            <li><a href="careers.html">Careers</a></li>
+            <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a></li>
+        </ul>
+    </div>
 
     <div id="mobile-bar" class="mobile-contact-bar">
         <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>

--- a/roof-repair.html
+++ b/roof-repair.html
@@ -24,12 +24,13 @@
 </head>
 <body>
     <header class="header">
+        <div class="hamburger"><i class="fas fa-bars"></i></div>
         <div class="logo-container">
             <a href="index.html">
                 <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
             </a>
         </div>
-        <nav class="main-nav">
+        <nav class="desktop-nav">
             <ul>
                 <li><a href="index.html#solutions">Solutions</a></li>
                 <li><a href="index.html#about">About Us</a></li>
@@ -39,19 +40,19 @@
                 <li><a href="careers.html">Careers</a></li>
             </ul>
         </nav>
-        <div class="hamburger"><i class="fas fa-bars"></i></div>
-        <div class="mobile-menu">
-            <ul>
-                <li><a href="index.html#solutions">Solutions</a></li>
-                <li><a href="index.html#about">About Us</a></li>
-                <li><a href="index.html#projects">Projects</a></li>
-                <li><a href="index.html#testimonials">Testimonials</a></li>
-                <li><a href="index.html#contact">Contact</a></li>
-                <li><a href="careers.html">Careers</a></li>
-                <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a></li>
-            </ul>
-        </div>
     </header>
+    <div class="mobile-menu">
+        <div class="close-menu">&times;</div>
+        <ul>
+            <li><a href="index.html#solutions">Solutions</a></li>
+            <li><a href="index.html#about">About Us</a></li>
+            <li><a href="index.html#projects">Projects</a></li>
+            <li><a href="index.html#testimonials">Testimonials</a></li>
+            <li><a href="index.html#contact">Contact</a></li>
+            <li><a href="careers.html">Careers</a></li>
+            <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a></li>
+        </ul>
+    </div>
 
     <div id="mobile-bar" class="mobile-contact-bar">
         <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>

--- a/scripts.js
+++ b/scripts.js
@@ -3,7 +3,8 @@ document.addEventListener("DOMContentLoaded", function () {
         const header = document.querySelector('.header');
         if (header) {
             const headerHeight = header.offsetHeight;
-            document.documentElement.style.setProperty('--header-height', `${headerHeight}px`);
+            const extraOffset = 10;
+            document.documentElement.style.setProperty('--header-height', `${headerHeight + extraOffset}px`);
         }
     }
     adjustHeaderOffset();

--- a/service-area.html
+++ b/service-area.html
@@ -24,12 +24,13 @@
 </head>
 <body>
     <header class="header">
+        <div class="hamburger"><i class="fas fa-bars"></i></div>
         <div class="logo-container">
             <a href="index.html">
                 <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
             </a>
         </div>
-        <nav class="main-nav">
+        <nav class="desktop-nav">
             <ul>
                 <li><a href="index.html#solutions">Solutions</a></li>
                 <li><a href="index.html#about">About Us</a></li>
@@ -39,19 +40,19 @@
                 <li><a href="careers.html">Careers</a></li>
             </ul>
         </nav>
-        <div class="hamburger"><i class="fas fa-bars"></i></div>
-        <div class="mobile-menu">
-            <ul>
-                <li><a href="index.html#solutions">Solutions</a></li>
-                <li><a href="index.html#about">About Us</a></li>
-                <li><a href="index.html#projects">Projects</a></li>
-                <li><a href="index.html#testimonials">Testimonials</a></li>
-                <li><a href="index.html#contact">Contact</a></li>
-                <li><a href="careers.html">Careers</a></li>
-                <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a></li>
-            </ul>
-        </div>
     </header>
+    <div class="mobile-menu">
+        <div class="close-menu">&times;</div>
+        <ul>
+            <li><a href="index.html#solutions">Solutions</a></li>
+            <li><a href="index.html#about">About Us</a></li>
+            <li><a href="index.html#projects">Projects</a></li>
+            <li><a href="index.html#testimonials">Testimonials</a></li>
+            <li><a href="index.html#contact">Contact</a></li>
+            <li><a href="careers.html">Careers</a></li>
+            <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a></li>
+        </ul>
+    </div>
 
     <div id="mobile-bar" class="mobile-contact-bar">
         <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>

--- a/siding.html
+++ b/siding.html
@@ -24,12 +24,13 @@
 </head>
 <body>
     <header class="header">
+        <div class="hamburger"><i class="fas fa-bars"></i></div>
         <div class="logo-container">
             <a href="index.html">
                 <img src="logo.png" alt="Romano Roofing Co Logo" class="logo">
             </a>
         </div>
-        <nav class="main-nav">
+        <nav class="desktop-nav">
             <ul>
                 <li><a href="index.html#solutions">Solutions</a></li>
                 <li><a href="index.html#about">About Us</a></li>
@@ -39,19 +40,19 @@
                 <li><a href="careers.html">Careers</a></li>
             </ul>
         </nav>
-        <div class="hamburger"><i class="fas fa-bars"></i></div>
-        <div class="mobile-menu">
-            <ul>
-                <li><a href="index.html#solutions">Solutions</a></li>
-                <li><a href="index.html#about">About Us</a></li>
-                <li><a href="index.html#projects">Projects</a></li>
-                <li><a href="index.html#testimonials">Testimonials</a></li>
-                <li><a href="index.html#contact">Contact</a></li>
-                <li><a href="careers.html">Careers</a></li>
-                <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a></li>
-            </ul>
-        </div>
     </header>
+    <div class="mobile-menu">
+        <div class="close-menu">&times;</div>
+        <ul>
+            <li><a href="index.html#solutions">Solutions</a></li>
+            <li><a href="index.html#about">About Us</a></li>
+            <li><a href="index.html#projects">Projects</a></li>
+            <li><a href="index.html#testimonials">Testimonials</a></li>
+            <li><a href="index.html#contact">Contact</a></li>
+            <li><a href="careers.html">Careers</a></li>
+            <li><a href="mailto:romanoroofingco@gmail.com" class="email-link" target="_blank"><i class="fas fa-envelope"></i></a></li>
+        </ul>
+    </div>
 
     <div id="mobile-bar" class="mobile-contact-bar">
         <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>

--- a/styles.css
+++ b/styles.css
@@ -37,7 +37,7 @@ ul {
 .header {
     background: #FF5733;
     color: #fff;
-    padding: 20px 20px;
+    padding: 25px 20px;
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -605,20 +605,20 @@ body {
     display: none; /* Hidden by default */
     position: fixed;
     top: 0;
-    right: 0;
+    left: 0;
     height: 100%; /* Full height of screen */
     width: 60%; /* Take up 60% of the screen */
     background: rgba(0, 0, 0, 0.8); /* Transparent dark background */
     color: #fff;
     z-index: 1500;
     padding-top: var(--header-height, 80px); /* Offset from header */
-    box-shadow: -2px 0 10px rgba(0, 0, 0, 0.5); /* Add a shadow for a sleek look */
+    box-shadow: 2px 0 10px rgba(0, 0, 0, 0.5); /* Add a shadow for a sleek look */
 }
 
 .close-menu {
     position: absolute;
     top: 15px;
-    left: 15px;
+    right: 15px;
     font-size: 1.8em;
     cursor: pointer;
 }
@@ -626,6 +626,7 @@ body {
 .mobile-menu ul {
     display: block;
     padding: 20px;
+    text-align: left;
 }
 
 .mobile-menu ul li {
@@ -686,7 +687,7 @@ body {
     }
 
     .header {
-        padding: 25px 20px;
+        padding: 35px 20px;
     }
 
     .logo {


### PR DESCRIPTION
## Summary
- expand header spacing and add extra offset so top content is not cropped
- shift mobile menu to slide from the left with a top-right close button
- unify navigation markup across service pages so hamburger links display consistently

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896aaec8d888321823877b4e959c85f