### PR TITLE
Adjust mobile padding for hero and careers section

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -418,6 +418,7 @@ ul {
 /* Careers section styling */
 .careers-section {
     text-align: center;
+    padding-top: 120px;
 }
 
 .careers-section .careers-image {
@@ -680,6 +681,10 @@ body {
 
     body {
         padding-bottom: 0;
+    }
+
+    .main-banner {
+        padding-top: 120px;
     }
 
     .logo-container {


### PR DESCRIPTION
## Summary
- Increase top padding for mobile hero banner to keep its first image clear of the fixed header
- Add generous top padding to careers page so the title no longer crops under the header

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896b5c5a45c832183e35c3af9e7fbac