### PR TITLE
Restore Service Area link and adjust careers padding

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -56,7 +56,7 @@
 
     <div id="mobile-bar" class="mobile-contact-bar">
         <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
-        <a href="index.html#contact" class="btn">Get a Free Quote</a>
+        <a href="service-area.html"><i class="fas fa-map-marker-alt service-icon"></i> Service Area</a>
     </div>
 
     <section class="service-detail careers-section">

--- a/gutters.html
+++ b/gutters.html
@@ -56,7 +56,7 @@
 
     <div id="mobile-bar" class="mobile-contact-bar">
         <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
-        <a href="index.html#contact" class="btn">Get a Free Quote</a>
+        <a href="service-area.html"><i class="fas fa-map-marker-alt service-icon"></i> Service Area</a>
     </div>
 
     <section class="service-detail">

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
 
     <div id="mobile-bar" class="mobile-contact-bar">
         <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
-        <a href="#contact" class="btn">Get a Free Quote</a>
+        <a href="service-area.html"><i class="fas fa-map-marker-alt service-icon"></i> Service Area</a>
     </div>
 
     <!-- Main Banner -->

--- a/roof-installation.html
+++ b/roof-installation.html
@@ -56,7 +56,7 @@
 
     <div id="mobile-bar" class="mobile-contact-bar">
         <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
-        <a href="index.html#contact" class="btn">Get a Free Quote</a>
+        <a href="service-area.html"><i class="fas fa-map-marker-alt service-icon"></i> Service Area</a>
     </div>
 
     <section class="service-detail">

--- a/roof-repair.html
+++ b/roof-repair.html
@@ -56,7 +56,7 @@
 
     <div id="mobile-bar" class="mobile-contact-bar">
         <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
-        <a href="index.html#contact" class="btn">Get a Free Quote</a>
+        <a href="service-area.html"><i class="fas fa-map-marker-alt service-icon"></i> Service Area</a>
     </div>
 
     <section class="service-detail">

--- a/service-area.html
+++ b/service-area.html
@@ -56,7 +56,7 @@
 
     <div id="mobile-bar" class="mobile-contact-bar">
         <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
-        <a href="index.html#contact" class="btn">Get a Free Quote</a>
+        <a href="service-area.html"><i class="fas fa-map-marker-alt service-icon"></i> Service Area</a>
     </div>
 
     <section class="service-detail">

--- a/siding.html
+++ b/siding.html
@@ -56,7 +56,7 @@
 
     <div id="mobile-bar" class="mobile-contact-bar">
         <a href="tel:+17735318473"><i class="fas fa-phone"></i> Call Us</a>
-        <a href="index.html#contact" class="btn">Get a Free Quote</a>
+        <a href="service-area.html"><i class="fas fa-map-marker-alt service-icon"></i> Service Area</a>
     </div>
 
     <section class="service-detail">

--- a/styles.css
+++ b/styles.css
@@ -127,6 +127,11 @@ ul {
     display: none;
 }
 
+.mobile-contact-bar .service-icon {
+    color: #FF5733;
+    margin-right: 5px;
+}
+
 .btn.primary-btn {
     background: #007BFF;
     color: #fff;
@@ -418,7 +423,7 @@ ul {
 /* Careers section styling */
 .careers-section {
     text-align: center;
-    padding-top: 120px;
+    padding-top: 160px;
 }
 
 .careers-section .careers-image {


### PR DESCRIPTION
## Summary
- Add orange Service Area link to mobile contact bar across pages
- Increase top padding on careers page for improved spacing

## Testing
- `npx -y htmlhint index.html service-area.html careers.html roof-repair.html gutters.html roof-installation.html siding.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6896bc6cfd048321b35d52ce0870a2b7