### PR TITLE
Refine mobile spacing for subfooter and service pages

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -679,7 +679,7 @@ body {
 /* Responsive adjustments */
 @media (max-width: 768px) {
     .service-detail {
-        padding: 60px 20px 40px;
+        padding: 120px 20px 40px;
     }
     .careers-section,
     .service-area-section {
@@ -712,7 +712,7 @@ body {
         transform: translateX(-16px); /* Align logo with page content */
     }
     .sub-footer {
-        padding-bottom: calc(0.4rem + 60px); /* Ensure visibility above mobile bar */
+        padding-bottom: calc(0.4rem + 50px); /* Reduce excess whitespace above mobile bar */
     }
 }
 


### PR DESCRIPTION
## Summary
- reduce sub-footer padding on mobile to trim excess whitespace
- increase mobile top padding on service detail sections to prevent header overlap

## Testing
- `npx stylelint styles.css` *(fails: 403 Forbidden - GET https://registry.npmjs.org/stylelint)*

------
https://chatgpt.com/codex/tasks/task_e_6896c93cf1c083219a8cf678a447ee25