### PR TITLE
Adjust service page padding and carousel widths

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -76,15 +76,15 @@ document.addEventListener("DOMContentLoaded", function () {
 
     // Carousel functionality
     const carousel = document.querySelector('.carousel-images');
-    const carouselImages = document.querySelectorAll('.carousel-img');
+    const carouselItems = document.querySelectorAll('.carousel-item');
     const leftArrow = document.querySelector('.left-arrow');
     const rightArrow = document.querySelector('.right-arrow');
 
     let currentIndex = 0;
-    const totalImages = carouselImages.length;
-    const imagesToShow = 3;  // Showing 3 images at a time
-    const maxIndex = totalImages - imagesToShow;
-    let imageWidth = carouselImages[0].clientWidth + 20; // Image width + margin/padding
+    const totalItems = carouselItems.length;
+    const imagesToShow = 1;  // Show one image at a time
+    const maxIndex = totalItems - imagesToShow;
+    let imageWidth = carouselItems[0].clientWidth;
 
     // Right arrow click event
     if (rightArrow) {
@@ -110,7 +110,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
     // Update image width on window resize to ensure responsiveness
     window.addEventListener('resize', () => {
-        imageWidth = carouselImages[0].clientWidth + 20;
+        imageWidth = carouselItems[0].clientWidth;
         updateCarousel();  // Recalculate and update the transform position
     });
 

--- a/styles.css
+++ b/styles.css
@@ -385,7 +385,7 @@ ul {
 /* Service Detail */
 .service-detail {
     text-align: center;
-    padding: 60px 20px 40px;
+    padding: 80px 20px 40px;
 }
 .service-detail p {
     max-width: 800px;
@@ -477,7 +477,7 @@ ul {
 
 .carousel {
     overflow: hidden;
-    width: 90%;
+    width: 100%;
     max-width: 1000px; /* Limit the width on larger screens */
     position: relative;
     display: flex;
@@ -490,7 +490,7 @@ ul {
 }
 
 .carousel-item {
-    width: 33%; /* Show 2-3 images per view */
+    flex: 0 0 100%;
     text-align: center;
 }
 
@@ -612,7 +612,7 @@ body {
     background-color: white; /* White background */
     color: black; /* Black text */
     text-align: center; /* Center the text */
-    padding: 0.4rem 0; /* Further reduced padding to decrease the height */
+    padding: 0.2rem 0; /* Further reduced padding to decrease the height */
     width: 100%;
     font-size: 0.8rem; /* Small font size */
     box-shadow: 0 -1px 5px rgba(0, 0, 0, 0.1); /* Optional shadow for a slight lift */
@@ -620,7 +620,7 @@ body {
     position: relative; /* Prevent overlap with other elements */
     bottom: 0;
     left: 0;
-    margin-top: 20px;
+    margin-top: 5px;
 }
 
 /* Mobile Menu */


### PR DESCRIPTION
## Summary
- Increase top padding for service detail sections so headings clear the fixed header
- Reduce sub-footer spacing and tighten padding on all pages
- Restore full-width carousel images and update slider logic

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896cc2a9e88832182e72ddb26dd247a