### PR TITLE
Fix carousel titles visibility

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -476,7 +476,8 @@ ul {
 }
 
 .carousel {
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: visible;
     width: 100%;
     max-width: 1000px; /* Limit the width on larger screens */
     position: relative;


### PR DESCRIPTION
## Summary
- Ensure titles in homepage carousel remain visible by showing vertical overflow

## Testing
- `npm test` (fails: could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_6896cee465b88321b6201f75dd1492a8