### PR TITLE
Fix desktop mobile bar and responsive navigation

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -34,10 +34,31 @@ document.addEventListener("DOMContentLoaded", function () {
         });
     }
 
-    // Hamburger menu functionality
+    // Hamburger menu and responsive navigation
     const mobileMenu = document.querySelector('.mobile-menu');
     const hamburger = document.querySelector('.hamburger');
     const closeMenu = document.querySelector('.close-menu');
+    const desktopNav = document.querySelector('.desktop-nav');
+    const logoContainer = document.querySelector('.logo-container');
+
+    // Switch to hamburger menu if the logo overlaps navigation links
+    function updateNavDisplay() {
+        if (!desktopNav || !hamburger || !logoContainer) return;
+        const navRect = desktopNav.getBoundingClientRect();
+        const logoRect = logoContainer.getBoundingClientRect();
+
+        if (navRect.left < logoRect.right + 20) {
+            desktopNav.style.display = 'none';
+            hamburger.style.display = 'block';
+        } else {
+            desktopNav.style.display = 'block';
+            hamburger.style.display = 'none';
+        }
+    }
+
+    updateNavDisplay();
+    window.addEventListener('resize', updateNavDisplay);
+    window.addEventListener('load', updateNavDisplay);
 
     if (hamburger && mobileMenu) {
         hamburger.addEventListener('click', function (e) {

--- a/styles.css
+++ b/styles.css
@@ -715,13 +715,14 @@ body {
     }
 }
 
+/* Keep the mobile contact bar visible on all screen sizes */
 @media (min-width: 769px) {
     body {
-        padding-bottom: 0;
+        padding-bottom: 100px; /* Maintain space for the contact bar */
     }
 
     .mobile-contact-bar {
-        display: none;
+        display: flex;
     }
 }
 


### PR DESCRIPTION
## Summary
- Keep mobile contact bar visible on all screen sizes by removing desktop-only hiding styles.
- Add JavaScript that detects when the logo overlaps navigation links and toggles the hamburger menu accordingly.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68975ff7ba3883218da2ec971348c053