### PR TITLE
Ensure footer displays above mobile bar and update styling

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -119,10 +119,10 @@
     </section>
 
     <footer class="footer">
-        <p>Licensed, Insured &amp; Bonded!</p>
+        <p><strong>Licensed, Insured, and Bonded!</strong></p>
         <p>&copy; 2024 Romano Roofing Co. </p>
         <div class="sub-footer">
-            © Copyright 2024 | Developed by <a href="https://SaasProductized.com" target="_blank" style="color: inherit;">SaaS Productized Co</a>. | <br>  All Rights Reserved
+            © Copyright 2024 | Developed by <a href="https://SaasProductized.com" target="_blank">SaaS Productized Co.</a> | <br>  All Rights Reserved
         </div>
     </footer>
 

--- a/gutters.html
+++ b/gutters.html
@@ -87,10 +87,10 @@
     </section>
 
     <footer class="footer">
-        <p>Licensed, Insured & Bonded!</p>
+        <p><strong>Licensed, Insured, and Bonded!</strong></p>
         <p>&copy; 2024 Romano Roofing Co. </p>
         <div class="sub-footer">
-            © Copyright 2024 | Developed by <a href="https://SaasProductized.com" target="_blank" style="color: inherit;">SaaS Productized Co</a>. | <br>  All Rights Reserved
+            © Copyright 2024 | Developed by <a href="https://SaasProductized.com" target="_blank">SaaS Productized Co.</a> | <br>  All Rights Reserved
         </div>
     </footer>
 

--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
     <!-- Main Banner -->
     <section class="main-banner">
         <p>"Delivering top-tier roofing solutions across Chicagoland for over two decades."</p>
-        <a href="#contact" class="btn primary-btn">Request Estimate</a>
+        <a href="#contact" class="btn primary-btn glow-btn">Request Estimate</a>
     </section>
     
     <!-- About Section -->
@@ -207,10 +207,10 @@
 
     <!-- Footer -->
     <footer class="footer">
-        <p>Licensed, Insured & Bonded!</p>
+        <p><strong>Licensed, Insured, and Bonded!</strong></p>
         <p>&copy; 2024 Romano Roofing Co. </p>
         <div class="sub-footer">
-            © Copyright 2024 | Developed by <a href="https://SaasProductized.com" target="_blank" style="color: inherit;">SaaS Productized Co</a>. | <br>  All Rights Reserved
+            © Copyright 2024 | Developed by <a href="https://SaasProductized.com" target="_blank">SaaS Productized Co.</a> | <br>  All Rights Reserved
         </div>
     </footer>
 

--- a/roof-installation.html
+++ b/roof-installation.html
@@ -87,10 +87,10 @@
     </section>
 
     <footer class="footer">
-        <p>Licensed, Insured & Bonded!</p>
+        <p><strong>Licensed, Insured, and Bonded!</strong></p>
         <p>&copy; 2024 Romano Roofing Co. </p>
         <div class="sub-footer">
-            © Copyright 2024 | Developed by <a href="https://SaasProductized.com" target="_blank" style="color: inherit;">SaaS Productized Co</a>. | <br>  All Rights Reserved
+            © Copyright 2024 | Developed by <a href="https://SaasProductized.com" target="_blank">SaaS Productized Co.</a> | <br>  All Rights Reserved
         </div>
     </footer>
 

--- a/roof-repair.html
+++ b/roof-repair.html
@@ -87,10 +87,10 @@
     </section>
 
     <footer class="footer">
-        <p>Licensed, Insured & Bonded!</p>
+        <p><strong>Licensed, Insured, and Bonded!</strong></p>
         <p>&copy; 2024 Romano Roofing Co. </p>
         <div class="sub-footer">
-            © Copyright 2024 | Developed by <a href="https://SaasProductized.com" target="_blank" style="color: inherit;">SaaS Productized Co</a>. | <br>  All Rights Reserved
+            © Copyright 2024 | Developed by <a href="https://SaasProductized.com" target="_blank">SaaS Productized Co.</a> | <br>  All Rights Reserved
         </div>
     </footer>
 

--- a/service-area.html
+++ b/service-area.html
@@ -108,10 +108,10 @@
     </section>
 
     <footer class="footer">
-        <p>Licensed, Insured & Bonded!</p>
+        <p><strong>Licensed, Insured, and Bonded!</strong></p>
         <p>&copy; 2024 Romano Roofing Co. </p>
         <div class="sub-footer">
-            © Copyright 2024 | Developed by <a href="https://SaasProductized.com" target="_blank" style="color: inherit;">SaaS Productized Co</a>. | <br>  All Rights Reserved
+            © Copyright 2024 | Developed by <a href="https://SaasProductized.com" target="_blank">SaaS Productized Co.</a> | <br>  All Rights Reserved
         </div>
     </footer>
 

--- a/siding.html
+++ b/siding.html
@@ -87,10 +87,10 @@
     </section>
 
     <footer class="footer">
-        <p>Licensed, Insured & Bonded!</p>
+        <p><strong>Licensed, Insured, and Bonded!</strong></p>
         <p>&copy; 2024 Romano Roofing Co. </p>
         <div class="sub-footer">
-            © Copyright 2024 | Developed by <a href="https://SaasProductized.com" target="_blank" style="color: inherit;">SaaS Productized Co</a>. | <br> All Rights Reserved
+            © Copyright 2024 | Developed by <a href="https://SaasProductized.com" target="_blank">SaaS Productized Co.</a> | <br> All Rights Reserved
         </div>
     </footer>
 

--- a/styles.css
+++ b/styles.css
@@ -152,6 +152,9 @@ ul {
 .btn.primary-btn:hover {
     background: #0056b3;
 }
+.glow-btn {
+    box-shadow: 0 0 10px 3px rgba(255, 255, 255, 0.8);
+}
 .btn.read-more-btn {
     background: #007BFF;
     color: #fff;
@@ -635,7 +638,7 @@ body {
     color: black; /* Black text */
     text-align: center; /* Center the text */
     padding-top: 0.4rem;
-    padding-bottom: calc(0.4rem + 2px);
+    padding-bottom: calc(0.4rem + 2px + env(safe-area-inset-bottom));
     width: 100%;
     font-size: 0.8rem; /* Small font size */
     box-shadow: 0 -1px 5px rgba(0, 0, 0, 0.1); /* Optional shadow for a slight lift */
@@ -644,6 +647,16 @@ body {
     bottom: 0;
     left: 0;
     margin-top: 5px;
+    margin-bottom: 60px;
+}
+
+.sub-footer a {
+    color: #000;
+    font-weight: bold;
+}
+
+.footer p strong {
+    color: #fff;
 }
 
 /* Mobile Menu */


### PR DESCRIPTION
## Summary
- add a white glow behind the main "Request Estimate" button
- keep sub-footer visible above the mobile bar and emphasize SaaS Productized Co. link
- bold the "Licensed, Insured, and Bonded!" notice across all footers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897629c6adc832187da86d1650992bf