### PR TITLE
Adjust sub-footer spacing and mobile bar alignment

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -627,6 +627,7 @@ html, body {
 
 body {
     flex: 1 0 auto; /* Let the body grow and take available space */
+    padding-bottom: calc(60px + env(safe-area-inset-bottom)); /* Reserve space for mobile bar */
 }
 
 .main-content {
@@ -647,8 +648,8 @@ body {
     position: relative; /* Prevent overlap with other elements */
     bottom: 0;
     left: 0;
-    margin-top: 5px;
-    margin-bottom: 60px;
+    margin-top: 10px; /* Space above sub-footer */
+    margin-bottom: 0; /* Remove gap below sub-footer */
 }
 
 .sub-footer a {
@@ -731,10 +732,6 @@ body {
 
 /* Keep the mobile contact bar visible on all screen sizes */
 @media (min-width: 769px) {
-    body {
-        padding-bottom: 100px; /* Maintain space for the contact bar */
-    }
-
     .mobile-contact-bar {
         display: flex;
     }


### PR DESCRIPTION
## Summary
- space sub-footer text away from main footer and remove bottom margin
- reserve viewport space for mobile contact bar via body padding
- drop unnecessary desktop body padding override

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6897650ca8c08321847fa60683aa69ee