### PR TITLE
Use consistent orange color for service icons

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -204,7 +204,7 @@ ul {
     font-size: 2em;
     margin-bottom: 10px;
     display: block;
-    color: orange;
+    color: #FF5733;
 }
 
 .about {
@@ -707,7 +707,7 @@ body {
 }
 
 .mobile-menu ul li a.active {
-    color: orange;
+    color: #FF5733;
 }
 
 .mobile-menu.show {


### PR DESCRIPTION
## Summary
- ensure service section icons use brand orange (#FF5733)
- align mobile menu active link color with brand color

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68976640e41883218a38b699c2a75ffc