### PR TITLE
Fix subfooter overlap with mobile bar

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,7 @@
 /* Reset and base styles */
+:root {
+    --mobile-bar-height: 60px;
+}
 body, h1, h2, h3, p, ul, li, a, img {
     margin: 0;
     padding: 0;
@@ -22,7 +25,7 @@ body {
     position: relative;
     padding-top: var(--header-height, 0px);
     /* Leave room for the mobile contact bar */
-    padding-bottom: 100px;
+    padding-bottom: var(--mobile-bar-height);
     overflow-x: hidden;
 }
 a {
@@ -135,6 +138,7 @@ ul {
     justify-content: space-around;
     padding: 10px 0;
     z-index: 950;
+    min-height: var(--mobile-bar-height);
 }
 
 .mobile-contact-bar .service-icon {
@@ -627,7 +631,7 @@ html, body {
 
 body {
     flex: 1 0 auto; /* Let the body grow and take available space */
-    padding-bottom: calc(60px + env(safe-area-inset-bottom)); /* Reserve space for mobile bar */
+    padding-bottom: calc(var(--mobile-bar-height) + env(safe-area-inset-bottom)); /* Reserve space for mobile bar */
 }
 
 .main-content {
@@ -640,7 +644,7 @@ body {
     color: black; /* Black text */
     text-align: center; /* Center the text */
     padding-top: 0.4rem;
-    padding-bottom: calc(0.4rem + 2px + env(safe-area-inset-bottom));
+    padding-bottom: calc(0.4rem + var(--mobile-bar-height) + env(safe-area-inset-bottom));
     width: 100%;
     font-size: 0.8rem; /* Small font size */
     box-shadow: 0 -1px 5px rgba(0, 0, 0, 0.1); /* Optional shadow for a slight lift */
@@ -648,7 +652,7 @@ body {
     position: relative; /* Prevent overlap with other elements */
     bottom: 0;
     left: 0;
-    margin-top: 10px; /* Space above sub-footer */
+    margin-top: 20px; /* Space above sub-footer */
     margin-bottom: 0; /* Remove gap below sub-footer */
 }
 


### PR DESCRIPTION
## Summary
- add CSS variable for mobile bar height and use it to reserve space in layout
- adjust sub-footer spacing so it clears the mobile contact bar and sits lower than footer text
- ensure mobile contact bar respects the shared height variable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689767696a8c8321933dc78115f63d3c