### PR TITLE
Reduce mobile bar size

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,6 +1,6 @@
 /* Reset and base styles */
 :root {
-    --mobile-bar-height: 60px;
+    --mobile-bar-height: 40px;
 }
 body, h1, h2, h3, p, ul, li, a, img {
     margin: 0;
@@ -138,7 +138,6 @@ ul {
     justify-content: space-around;
     padding: 10px 0;
     z-index: 950;
-    min-height: var(--mobile-bar-height);
 }
 
 .mobile-contact-bar .service-icon {


### PR DESCRIPTION
## Summary
- Decrease mobile contact bar height to restore previous appearance
- Remove forced minimum height while preserving spacing for the sub-footer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68976bbda4d083218e314cbbddd1d8cf