### PR TITLE
Animate star rating and fix estimate button layout

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -156,14 +156,34 @@ document.addEventListener("DOMContentLoaded", function () {
         reviewsText.textContent = `(${reviewsCount} Ratings & Reviews)`;
 
         const fullStars = Math.floor(ratingValue);
+        const hasHalfStar = ratingValue - fullStars >= 0.5;
+
+        // create empty stars
         for (let i = 0; i < 5; i++) {
             const star = document.createElement('i');
-            if (i < fullStars) {
-                star.classList.add('fas', 'fa-star');
-            } else {
-                star.classList.add('far', 'fa-star');
-            }
+            star.classList.add('far', 'fa-star');
             starsContainer.appendChild(star);
         }
+
+        // animate stars filling
+        let index = 0;
+        const starElements = starsContainer.children;
+
+        function fillStars() {
+            if (index < fullStars) {
+                const star = starElements[index];
+                star.classList.replace('far', 'fas');
+                star.classList.add('filled');
+                index++;
+                setTimeout(fillStars, 200);
+            } else if (hasHalfStar && index < starElements.length) {
+                const star = starElements[index];
+                star.classList.replace('far', 'fas');
+                star.classList.remove('fa-star');
+                star.classList.add('fa-star-half-alt', 'filled');
+            }
+        }
+
+        fillStars();
     }
 });

--- a/styles.css
+++ b/styles.css
@@ -127,9 +127,8 @@ ul {
 }
 
 .google-rating-widget {
-    display: inline-flex;
-    justify-content: center;
-    align-items: center;
+    display: block;
+    text-align: center;
     font-size: 0.9em;
     color: #fff;
     margin-bottom: 20px;
@@ -142,11 +141,16 @@ ul {
 
 .google-rating-widget .stars {
     display: inline-flex;
-    color: #FFD700;
 }
 
 .google-rating-widget .stars i {
     margin-right: 2px;
+    color: #555;
+    transition: color 0.3s;
+}
+
+.google-rating-widget .stars i.filled {
+    color: #FFD700;
 }
 
 .google-rating-widget .reviews-text {


### PR DESCRIPTION
## Summary
- Animate Google review stars so they fill sequentially on load
- Place the Request Estimate button on its own line beneath the rating widget

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898fa5dbd2083218eb4828010829bad