### PR TITLE
Increase spacing beneath rating widget

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -131,7 +131,7 @@ ul {
     text-align: center;
     font-size: 0.9em;
     color: #fff;
-    margin-bottom: 20px;
+    margin-bottom: 40px;
 }
 
 .google-rating-widget .rating-value {


### PR DESCRIPTION
## Summary
- Add extra space between the Google rating stars widget and the "Request Estimate" button for improved layout.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899058889f0832190a4b0ff0bb7ca6b